### PR TITLE
feat: replace vanta with configurable gear background

### DIFF
--- a/src/app/components/gear-background/gear-background.component.html
+++ b/src/app/components/gear-background/gear-background.component.html
@@ -1,0 +1,13 @@
+<div class="gears-bg">
+  <ion-icon
+    *ngFor="let gear of gears"
+    name="cog-outline"
+    class="gear"
+    [style.left.%]="gear.left"
+    [style.bottom.px]="-gear.size"
+    [style.font-size.px]="gear.size"
+    [style.animation-duration.s]="gear.duration"
+    [style.animation-delay.s]="gear.delay"
+    [style.color]="color"
+  ></ion-icon>
+</div>

--- a/src/app/components/gear-background/gear-background.component.scss
+++ b/src/app/components/gear-background/gear-background.component.scss
@@ -1,0 +1,30 @@
+:host {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.gear {
+  position: absolute;
+  animation-name: rise;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  will-change: transform;
+  opacity: 0.6;
+}
+
+@keyframes rise {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateY(-120vh) rotate(360deg);
+    opacity: 0;
+  }
+}

--- a/src/app/components/gear-background/gear-background.component.ts
+++ b/src/app/components/gear-background/gear-background.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+interface Gear {
+  left: number;
+  size: number;
+  duration: number;
+  delay: number;
+}
+
+@Component({
+  selector: 'app-gear-background',
+  standalone: false,
+  templateUrl: './gear-background.component.html',
+  styleUrls: ['./gear-background.component.scss'],
+})
+export class GearBackgroundComponent implements OnInit {
+  @Input() gearCount = 6;
+  @Input() color = '#00c16a';
+  @Input() minSize = 40;
+  @Input() maxSize = 80;
+  @Input() minDuration = 10;
+  @Input() maxDuration = 20;
+
+  gears: Gear[] = [];
+
+  ngOnInit(): void {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    this.generateGears();
+  }
+
+  private generateGears(): void {
+    this.gears = Array.from({ length: this.gearCount }).map(() => {
+      const size = this.random(this.minSize, this.maxSize);
+      return {
+        left: Math.random() * 100,
+        size,
+        duration: this.random(this.minDuration, this.maxDuration),
+        delay: Math.random() * this.maxDuration,
+      };
+    });
+  }
+
+  private random(min: number, max: number): number {
+    return Math.random() * (max - min) + min;
+  }
+}
+

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -5,9 +5,10 @@ import { IonicModule } from '@ionic/angular';
 
 import { LoginPageRoutingModule } from './login-routing.module';
 import { LoginPage } from './login.page';
+import { GearBackgroundComponent } from '../components/gear-background/gear-background.component';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, IonicModule, LoginPageRoutingModule],
-  declarations: [LoginPage],
+  declarations: [LoginPage, GearBackgroundComponent],
 })
 export class LoginPageModule {}

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,5 +1,5 @@
 <ion-content class="ion-padding" fullscreen="true">
-  <div #vantaRef class="vanta-bg"></div>
+  <app-gear-background [gearCount]="6"></app-gear-background>
   <div class="content-wrapper">
     <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 32px;">
       <img src="assets/img/logo.png" alt="Logo" style="max-width: 150px; height: auto;">

--- a/src/app/login/login.page.scss
+++ b/src/app/login/login.page.scss
@@ -4,17 +4,6 @@ ion-content {
   position: relative;
 }
 
-.vanta-bg {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-}
-
-.vanta-bg canvas {
-  opacity: 0.2;
-  pointer-events: none;
-}
-
 .content-wrapper {
   position: relative;
   z-index: 1;

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
@@ -10,9 +10,7 @@ import { ThemeService } from '../services/theme.service';
   standalone: false,
   styleUrls: ['./login.page.scss'],
 })
-export class LoginPage implements AfterViewInit, OnDestroy {
-  @ViewChild('vantaRef', { static: true }) vantaRef!: ElementRef;
-  private vantaEffect?: any;
+export class LoginPage {
 
   form: FormGroup;
   private fb = inject(FormBuilder);
@@ -25,45 +23,6 @@ export class LoginPage implements AfterViewInit, OnDestroy {
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
     });
-  }
-
-  ngAfterViewInit(): void {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return;
-    }
-
-    const loadScript = (src: string) =>
-      new Promise<void>((resolve) => {
-        const script = document.createElement('script');
-        script.src = src;
-        script.onload = () => resolve();
-        document.body.appendChild(script);
-      });
-
-    const init = () => {
-      this.vantaEffect = (window as any).VANTA.WAVES({
-        el: this.vantaRef.nativeElement,
-        mouseControls: false,
-        touchControls: false,
-        gyroControls: false,
-        waveHeight: 15,
-        waveSpeed: 0.5,
-        color: 0x00c16a,
-      });
-    };
-
-    const scripts: Promise<void>[] = [];
-    if (!(window as any).THREE) {
-      scripts.push(loadScript('https://unpkg.com/three@0.152.2/build/three.min.js'));
-    }
-    if (!(window as any).VANTA) {
-      scripts.push(loadScript('https://unpkg.com/vanta@latest/dist/vanta.waves.min.js'));
-    }
-    Promise.all(scripts).then(init);
-  }
-
-  ngOnDestroy(): void {
-    this.vantaEffect?.destroy();
   }
 
   get themeIcon(): string {


### PR DESCRIPTION
## Summary
- replace Vanta effect with configurable gear animation background
- integrate background component into login page

## Testing
- `CHROME_BIN=/usr/bin/chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires snap-based chromium)*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa925d34fc8329ac28d5f5dc87648d