### PR TITLE
feat: enhance sales dashboard with charts and service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
         "@capacitor/keyboard": "7.0.2",
         "@capacitor/status-bar": "7.0.2",
         "@ionic/angular": "^8.0.0",
+        "apexcharts": "^5.3.4",
         "ionicons": "^7.0.0",
+        "lucide-angular": "^0.541.0",
+        "ng-apexcharts": "^2.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -6487,6 +6490,62 @@
         "@rollup/rollup-win32-x64-msvc": "4.34.9"
       }
     },
+    "node_modules/@svgdotjs/svg.draggable.js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.6.tgz",
+      "integrity": "sha512-7iJFm9lL3C40HQcqzEfezK2l+dW2CpoVY3b77KQGqc8GXWa6LhhmX5Ckv7alQfUXBuZbjpICZ+Dvq1czlGx7gA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
+    "node_modules/@svgdotjs/svg.filter.js": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.filter.js/-/svg.filter.js-3.0.9.tgz",
+      "integrity": "sha512-/69XMRCDoam2HgC4ldHIaDgeQf1ViHIsa0Ld4uWgiXtZ+E24DWHe/9Ib6kbNiZ7WRIdlVokUDR1Fg0kjIpkfbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@svgdotjs/svg.js": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
+      "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Fuzzyma"
+      }
+    },
+    "node_modules/@svgdotjs/svg.resize.js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.resize.js/-/svg.resize.js-2.0.5.tgz",
+      "integrity": "sha512-4heRW4B1QrJeENfi7326lUPYBCevj78FJs8kfeDxn5st0IYPIRXoTtOSYvTzFWgaWWXd3YCDE6ao4fmv91RthA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18"
+      },
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4",
+        "@svgdotjs/svg.select.js": "^4.0.1"
+      }
+    },
+    "node_modules/@svgdotjs/svg.select.js": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
+      "integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18"
+      },
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -7225,6 +7284,12 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/@yr/monotone-cubic-spline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
+      "license": "MIT"
+    },
     "node_modules/abbrev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -7501,6 +7566,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.3.4.tgz",
+      "integrity": "sha512-N0gNh8uLu/BN8N+BCphNK+gZAoSoUtDDn1jFGB+3+EMcv8s6vajuP3W0g4dMLTRp6chFkjMmQK3uD8pz4ISmLA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@svgdotjs/svg.draggable.js": "^3.0.4",
+        "@svgdotjs/svg.filter.js": "^3.0.8",
+        "@svgdotjs/svg.js": "^3.2.4",
+        "@svgdotjs/svg.resize.js": "^2.0.2",
+        "@svgdotjs/svg.select.js": "^4.0.1",
+        "@yr/monotone-cubic-spline": "^1.0.3"
       }
     },
     "node_modules/are-docs-informative": {
@@ -13278,6 +13357,19 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-angular": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-angular/-/lucide-angular-0.541.0.tgz",
+      "integrity": "sha512-k41TUQRBoq2x1rTmdnz1n0SIfdZ/HzB7pnJEC28Hn9GWNRLVhEKeee0Fa4fB44aJKwdm0brmue5dq07NB1GnSw==",
+      "license": "ISC",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "13.x - 20.x",
+        "@angular/core": "13.x - 20.x"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -13875,6 +13967,20 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ng-apexcharts": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ng-apexcharts/-/ng-apexcharts-2.0.1.tgz",
+      "integrity": "sha512-YWrnpoKzReDgb/BRbIdG7PjjHN0JRFGDdmL95NuVZ7IombWjmQKKFrY0k56xywGygY/swlZhURvFcS9eSR9uew==",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/core": "^20.0.0",
+        "apexcharts": "^5.3.2",
+        "rxjs": "^7.8.2"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "@capacitor/keyboard": "7.0.2",
     "@capacitor/status-bar": "7.0.2",
     "@ionic/angular": "^8.0.0",
+    "apexcharts": "^5.3.4",
     "ionicons": "^7.0.0",
+    "lucide-angular": "^0.541.0",
+    "ng-apexcharts": "^2.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/interfaces/IDashboardVendas.ts
+++ b/src/app/interfaces/IDashboardVendas.ts
@@ -1,0 +1,10 @@
+export interface IDashboardVendas {
+  clientesNovosHoje: number;
+  clientesAtendidosHoje: number;
+  totalClientesCadastrados: number;
+  eventosMarcados: number;
+  clientesFechados: number;
+  statusDistribution?: { status: string | null; count: number }[];
+  campanhaDistribution?: { campanha: string | null; count: number }[];
+  contatosPorDia?: { date: string; count: number }[];
+}

--- a/src/app/services/vendas/vendas.service.ts
+++ b/src/app/services/vendas/vendas.service.ts
@@ -1,0 +1,123 @@
+import { Injectable } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
+import { IDashboardVendas } from 'src/app/interfaces/IDashboardVendas';
+
+export interface PaginationMeta {
+  total: number; page: number; perPage: number; totalPages: number;
+}
+
+export type ApiResponse<T> = { success: boolean; data: T };
+export type PaginatedResponse<T> = { success: boolean; meta: PaginationMeta; data: T[] };
+
+export type PeriodoPayload = 'hoje' | 'semana' | 'mes' | [string, string];
+
+export type ClienteItem = {
+  nome: string;
+  updatedAt: string;
+  status: string | null;
+  observacao: string | null;
+  fechado?: string | null;
+  ultimoContato?: string | null;
+};
+
+export type EventoItem = {
+  data: string;
+  evento: string | null;
+  confirmado: boolean;
+  usuario?: { nomeCompleto: string | null } | null;
+  cliente: { nome: string | null } | null;
+};
+
+export type EventoUsuarioDTO = {
+  idEvento: number;
+  idUsuario?: number;
+  idCliente?: number;
+  data: string;
+  dataLocal?: string;
+  evento?: string | null;
+  confirmado?: boolean | null;
+  cliente?: { nome?: string | null } | null;
+};
+
+@Injectable({ providedIn: 'root' })
+export class VendasService {
+  private base = `${environment.apiURL}/clientes/dashboard`;
+
+  constructor(private http: HttpClient) {}
+
+  getAtendimento(periodo: PeriodoPayload): Observable<IDashboardVendas> {
+    return this.http
+      .post<ApiResponse<IDashboardVendas>>(this.base, { periodo })
+      .pipe(map(r => r.data));
+  }
+
+  getClientesNovosList(periodo: PeriodoPayload, page: number, perPage: number) {
+    return this.http.post<PaginatedResponse<ClienteItem>>(
+      `${this.base}/clientes-novos`, { periodo, page, perPage }
+    );
+  }
+
+  getClientesAtendidosList(periodo: PeriodoPayload, page: number, perPage: number) {
+    return this.http.post<PaginatedResponse<ClienteItem>>(
+      `${this.base}/clientes-atendidos`, { periodo, page, perPage }
+    );
+  }
+
+  getClientesFechadosList(periodo: PeriodoPayload, page: number, perPage: number) {
+    return this.http.post<PaginatedResponse<ClienteItem>>(
+      `${this.base}/clientes-fechados`, { periodo, page, perPage }
+    );
+  }
+
+  getEventosMarcadosList(periodo: PeriodoPayload, page: number, perPage: number) {
+    return this.http.post<PaginatedResponse<EventoItem>>(
+      `${this.base}/eventos-marcados`, { periodo, page, perPage }
+    );
+  }
+
+  getContatos(): Observable<any[]> {
+    return this.http.get<any[]>(`${environment.apiURL}/vendas`);
+  }
+
+  marcarContato(dados: any): Observable<any[]> {
+    return this.http.post<any[]>(`${environment.apiURL}/automacao/marcarContato`, dados);
+  }
+
+  confirmarEvento(idEvento: any) {
+    return this.http.post<any[]>(`${environment.apiURL}/clientes/eventos/${idEvento}/confirmar`, {});
+  }
+
+  cancelarEvento(idEvento: any) {
+    return this.http.post<any[]>(`${environment.apiURL}/clientes/eventos/${idEvento}/cancelar`, {});
+  }
+
+  getEventosUsuario(
+    idUsuario: number,
+    opts: { hoje?: boolean; tz?: string; confirmados?: boolean } = {}
+  ): Observable<EventoUsuarioDTO[]> {
+    const params: any = {
+      idUsuario,
+      ...(opts.hoje !== undefined ? { hoje: String(!!opts.hoje) } : {}),
+      ...(opts.tz ? { tz: opts.tz } : {}),
+      ...(opts.confirmados !== undefined ? { confirmados: String(!!opts.confirmados) } : {}),
+    };
+    return this.http.get<EventoUsuarioDTO[]>(
+      `${environment.apiURL}/clientes/eventos`,
+      { params }
+    );
+  }
+
+  getEventosIntervalo(
+    inicio: string,
+    fim: string,
+    tz = 'America/Maceio'
+  ): Observable<(EventoItem & { dataISO?: string; dataLocal?: string })[]> {
+    return this.http.get<(EventoItem & { dataISO?: string; dataLocal?: string })[]>(
+      `${environment.apiURL}/eventos/intervalo`,
+      { params: { inicio, fim, tz } }
+    );
+  }
+}
+

--- a/src/app/vendas-dashboard/vendas-dashboard.page.html
+++ b/src/app/vendas-dashboard/vendas-dashboard.page.html
@@ -1,201 +1,198 @@
-<ion-content class="ion-padding">
-
-  <!-- Loading -->
-  <ng-container *ngIf="loading">
-    <ion-skeleton-text animated style="width: 60%; height: 24px;"></ion-skeleton-text>
-    <ion-grid>
-      <ion-row>
-        <ion-col size="6" size-md="3" *ngFor="let _ of [1,2,3,4]">
-          <ion-card>
-            <ion-card-content>
-              <ion-skeleton-text animated style="width:40%"></ion-skeleton-text>
-              <ion-skeleton-text animated style="width:20%"></ion-skeleton-text>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
-  </ng-container>
-
-  <!-- Error -->
-  <ion-text color="medium" *ngIf="!loading && error">
-    {{ error }}
-  </ion-text>
-
-  <!-- Content -->
-  <ng-container *ngIf="!loading && data as d">
-
-    <!-- Header -->
-    <div class="header">
-      <div>
-        <h1 class="title">Relatório de Atendimento</h1>
-        <p class="subtitle">Acompanhe o desempenho do atendimento ao cliente</p>
+<div class="p-6 space-y-6">
+  @if (loading()) {
+    <div class="animate-pulse space-y-4">
+      <div class="h-8 bg-gray-200 rounded w-1/4"></div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        @for (_ of [1,2,3,4]; track _) {
+          <div class="h-32 bg-gray-200 rounded"></div>
+        }
       </div>
-      <div class="filters">
-        <ion-item lines="none" class="range-picker">
-          <ion-input type="date" [value]="range.start" (ionChange)="onRangeChange('start', $event)" placeholder="Início"></ion-input>
-          <span>—</span>
-          <ion-input type="date" [value]="range.end" (ionChange)="onRangeChange('end', $event)" placeholder="Fim"></ion-input>
-          <ion-button size="small" (click)="applyRange()" [disabled]="!rangeValid">Aplicar</ion-button>
-        </ion-item>
-        <ion-text color="danger" *ngIf="rangeError">{{ rangeError }}</ion-text>
+    </div>
+  }
 
-        <ion-buttons>
-          <ion-button size="small" [fill]="selectedPeriod==='hoje' ? 'solid' : 'outline'" (click)="setPeriod('hoje')">Hoje</ion-button>
-          <ion-button size="small" [fill]="selectedPeriod==='semana' ? 'solid' : 'outline'" (click)="setPeriod('semana')">Esta Semana</ion-button>
-          <ion-button size="small" [fill]="selectedPeriod==='mes' ? 'solid' : 'outline'" (click)="setPeriod('mes')">Este Mês</ion-button>
-        </ion-buttons>
+  @if (!loading() && error()) {
+    <div class="text-center text-gray-500">{{ error() }}</div>
+  }
+
+  @if (!loading() && data(); as d) {
+    <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+      <div>
+        <h1 class="text-3xl font-bold text-gray-900">Relatório de Atendimento</h1>
+        <p class="text-gray-600">Acompanhe o desempenho do atendimento ao cliente</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <div class="relative">
+          <input
+            type="date"
+            class="pl-12 px-3 py-1.5 border rounded"
+            [value]="range.start"
+            (change)="onRangeChange('start', $event.target.value ? new Date($event.target.value) : null)"
+            placeholder="Início" />
+        </div>
+        <span class="text-gray-400">—</span>
+        <div class="relative">
+          <input
+            type="date"
+            class="pl-8 px-3 py-1.5 border rounded"
+            [value]="range.end"
+            (change)="onRangeChange('end', $event.target.value ? new Date($event.target.value) : null)"
+            placeholder="Fim" />
+        </div>
+        <button class="px-3 py-1.5 rounded border" [class.bg-gray-900]="rangeValid" [class.text-white]="rangeValid" [disabled]="!rangeValid" (click)="applyRange()">Aplicar</button>
+        <div *ngIf="rangeError" class="text-xs text-red-600 ml-1">{{ rangeError }}</div>
+      </div>
+      <div class="flex gap-2">
+        <button (click)="setPeriod('hoje')" class="px-3 py-1.5 rounded border" [class.bg-gray-900]="selectedPeriod()==='hoje'" [class.text-white]="selectedPeriod()==='hoje'">Hoje</button>
+        <button (click)="setPeriod('semana')" class="px-3 py-1.5 rounded border" [class.bg-gray-900]="selectedPeriod()==='semana'" [class.text-white]="selectedPeriod()==='semana'">Esta Semana</button>
+        <button (click)="setPeriod('mes')" class="px-3 py-1.5 rounded border" [class.bg-gray-900]="selectedPeriod()==='mes'" [class.text-white]="selectedPeriod()==='mes'">Este Mês</button>
       </div>
     </div>
 
-    <!-- KPI Cards -->
-    <ion-grid class="kpi-grid">
-      <ion-row>
-        <ion-col size="6" size-md="3">
-          <ion-card button (click)="openModal('novos')">
-            <ion-card-header>
-              <ion-card-subtitle>Clientes Novos</ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <div class="kpi-value">{{ d.clientesNovosHoje }}</div>
-              <div class="kpi-desc">{{ selectedPeriodLabel() }}</div>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-
-        <ion-col size="6" size-md="3">
-          <ion-card button (click)="openModal('atendidos')">
-            <ion-card-header>
-              <ion-card-subtitle>Clientes Atendidos</ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <div class="kpi-value">{{ d.clientesAtendidosHoje }}</div>
-              <div class="kpi-desc">{{ selectedPeriodLabel() }}</div>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-
-        <ion-col size="6" size-md="3">
-          <ion-card>
-            <ion-card-header>
-              <ion-card-subtitle>Total Cadastrados</ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <div class="kpi-value">{{ d.totalClientesCadastrados }}</div>
-              <div class="kpi-desc">clientes ativos</div>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-
-        <ion-col size="6" size-md="3">
-          <ion-card button (click)="openModal('eventos')">
-            <ion-card-header>
-              <ion-card-subtitle>Eventos Marcados</ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <div class="kpi-value">{{ d.eventosMarcados }}</div>
-              <div class="kpi-desc">Eventos marcados</div>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-
-        <ion-col size="6" size-md="3">
-          <ion-card button (click)="openModal('fechados')">
-            <ion-card-header>
-              <ion-card-subtitle>Fechados</ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <div class="kpi-value">{{ d.clientesFechados }}</div>
-              <div class="kpi-desc">Vendas Fechadas</div>
-            </ion-card-content>
-          </ion-card>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
-
-    <!-- Secondary KPIs -->
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Clientes por Status</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <div *ngFor="let s of d.statusDistribution" class="status-row">
-          <span>{{ s.status || 'Sem status' }}</span>
-          <ion-progress-bar [value]="s.count / maxStatus"></ion-progress-bar>
-          <span class="count">{{ s.count }}</span>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div class="border rounded-xl p-4 hover:shadow-sm cursor-pointer" (click)="openModal('novos')">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Clientes Novos</div>
+          <lucide-icon name="user-plus" class="h-4 w-4 text-green-600"></lucide-icon>
         </div>
-      </ion-card-content>
-    </ion-card>
+        <div class="text-2xl font-bold text-green-600">{{ d.clientesNovosHoje }}</div>
+        <p class="text-xs text-gray-600">{{ selectedPeriod()==='hoje' ? 'hoje' : ('neste ' + selectedPeriod()) }}</p>
+      </div>
 
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Clientes por Campanha</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <div *ngFor="let c of d.campanhaDistribution" class="status-row">
-          <span>{{ c.campanha || 'Sem campanha' }}</span>
-          <ion-progress-bar [value]="c.count / totalCampanhas"></ion-progress-bar>
-          <span class="count">{{ c.count }}</span>
+      <div class="border rounded-xl p-4 hover:shadow-sm cursor-pointer" (click)="openModal('atendidos')">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Clientes Atendidos</div>
+          <lucide-icon name="phone" class="h-4 w-4 text-blue-600"></lucide-icon>
         </div>
-      </ion-card-content>
-    </ion-card>
+        <div class="text-2xl font-bold text-blue-600">{{ d.clientesAtendidosHoje }}</div>
+        <p class="text-xs text-gray-600">{{ selectedPeriod()==='hoje' ? 'hoje' : ('neste ' + selectedPeriod()) }}</p>
+      </div>
 
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Contatos por dia (último contato)</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <ion-list lines="none">
-          <ion-item *ngFor="let ct of d.contatosPorDia">
-            <ion-label>{{ formatDate(ct.date) }}</ion-label>
-            <ion-badge slot="end">{{ ct.count }}</ion-badge>
-          </ion-item>
-        </ion-list>
-      </ion-card-content>
-    </ion-card>
+      <div class="border rounded-xl p-4">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Total Cadastrados</div>
+          <lucide-icon name="users" class="h-4 w-4 text-purple-600"></lucide-icon>
+        </div>
+        <div class="text-2xl font-bold text-purple-600">{{ d.totalClientesCadastrados }}</div>
+        <p class="text-xs text-gray-600">clientes ativos</p>
+      </div>
 
-  </ng-container>
+      <div class="border rounded-xl p-4 hover:shadow-sm cursor-pointer" (click)="openModal('eventos')">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Eventos Marcados</div>
+          <lucide-icon name="calendar" class="h-4 w-4 text-blue-600"></lucide-icon>
+        </div>
+        <div class="text-2xl font-bold text-blue-600">{{ d.eventosMarcados }}</div>
+        <p class="text-xs text-gray-600">Eventos marcados</p>
+      </div>
 
-  <!-- MODAL -->
-  <ion-modal [isOpen]="modalOpen" (didDismiss)="closeModal()">
+      <div class="border rounded-xl p-4 hover:shadow-sm cursor-pointer" (click)="openModal('fechados')">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Fechados</div>
+          <lucide-icon name="receipt" class="h-4 w-4 text-green-600"></lucide-icon>
+        </div>
+        <div class="text-2xl font-bold text-green-600">{{ d.clientesFechados }}</div>
+        <p class="text-xs text-gray-600">Vendas Fechadas</p>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div class="border rounded-xl p-4">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Clientes por Status</div>
+        </div>
+        <div *ngIf="statusChart() as s">
+          <apx-chart [series]="s.series" [chart]="s.chart" [xaxis]="s.xaxis" [plotOptions]="s.plotOptions" [dataLabels]="s.dataLabels" [stroke]="s.stroke" [tooltip]="s.tooltip" [fill]="s.fill"></apx-chart>
+        </div>
+      </div>
+
+      <div class="border rounded-xl p-4">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Clientes por Campanha</div>
+        </div>
+        <div *ngIf="campanhaChart() as c">
+          <apx-chart [series]="c.series" [chart]="c.chart" [labels]="c.labels" [legend]="c.legend" [tooltip]="c.tooltip" [responsive]="c.responsive"></apx-chart>
+        </div>
+      </div>
+
+      <div class="border rounded-xl p-4 lg:col-span-2">
+        <div class="flex items-center justify-between pb-2">
+          <div class="text-sm font-medium">Contatos por dia (último contato)</div>
+        </div>
+        <div *ngIf="contatosChart() as ct">
+          <apx-chart [series]="ct.series" [chart]="ct.chart" [xaxis]="ct.xaxis" [dataLabels]="ct.dataLabels" [stroke]="ct.stroke" [tooltip]="ct.tooltip" [fill]="ct.fill"></apx-chart>
+        </div>
+      </div>
+    </div>
+  }
+
+  <ion-modal [isOpen]="modalOpen()" (didDismiss)="closeModal()">
     <ng-template>
-      <ion-header>
-        <ion-toolbar>
-          <ion-title>{{ modalTitle() }}</ion-title>
-          <ion-buttons slot="end">
-            <ion-button (click)="closeModal()">Fechar</ion-button>
-          </ion-buttons>
-        </ion-toolbar>
-      </ion-header>
-      <ion-content class="ion-padding">
-        <ng-container *ngIf="isClientList(); else eventosTpl">
-          <ion-list>
-            <ion-item *ngFor="let c of modalItems">
-              <h2>{{ c['evento'] }}</h2>
-              <p>{{ formatDate(c['updatedAt']) }}</p>
-              <p>{{ short(c['observacao']) }}</p>
-              <ion-badge slot="end" [color]="statusBadgeColor(c['status'])">
-                {{ c['status'] || 'Sem status' }}
-              </ion-badge>
-            </ion-item>
-          </ion-list>
-        </ng-container>
-        <ng-template #eventosTpl>
-          <ion-list>
-            <ion-item *ngFor="let e of modalItems">
-              <h2>Cliente: {{ e['cliente'] || '-' }}</h2>
-              <p>Data: {{ formatDate(e['data']) }}</p>
-              <p>Evento: {{ e['evento'] || '-' }}</p>
-              <p>Usuário: {{ e['usuario'] || '-' }}</p>
-              <ion-badge slot="end" [color]="e['confirmado'] ? 'success' : 'medium'">
-                {{ e['confirmado'] ? 'Confirmado' : 'Pendente' }}
-              </ion-badge>
-            </ion-item>
-          </ion-list>
-        </ng-template>
-      </ion-content>
+      <div class="p-4 space-y-4">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-bold">{{ modalTitle() }}</h2>
+          <button class="px-3 py-1.5 border rounded" (click)="closeModal()">Fechar</button>
+        </div>
+
+        @if (modalLoading()) {
+          <div class="space-y-2">
+            @for (_ of [1,2,3,4,5,6]; track _) {
+              <div class="h-16 bg-gray-100 animate-pulse rounded"></div>
+            }
+          </div>
+        } @else if (modalError()) {
+          <div class="text-red-600">{{ modalError() }}</div>
+        } @else if (modalItems().length === 0) {
+          <div class="text-gray-500">Nenhum registro no período.</div>
+        } @else {
+          @if (isClientList()) {
+            <div class="grid grid-cols-1 gap-3">
+              @for (c of modalItems(); track c['nome'] + c['updatedAt']) {
+                <div class="border rounded-xl p-3">
+                  <div class="flex items-center justify-between">
+                    <div class="font-semibold text-gray-900">{{ c['nome'] }}</div>
+                    <span class="text-xs px-2 py-1 rounded-full" [class]="statusPillClass(c['status'])">{{ c['status'] || 'Sem status' }}</span>
+                  </div>
+                  <div class="text-xs text-gray-500 mt-1">
+                    Atualizado em {{ formatDate(c['updatedAt']) }}
+                    @if (c['fechado']) {
+                      <span class="ml-2 text-green-700 font-semibold">fechado {{ formatDate(c['fechado']) }}</span>
+                    }
+                    @if (c['ultimoContato']) {
+                      <span class="ml-2 text-green-700 font-semibold">Contato Mais Recente {{ formatDate(c['ultimoContato']) }}</span>
+                    }
+                  </div>
+                  <div class="text-sm text-gray-700 mt-2">{{ short(c['observacao']) }}</div>
+                </div>
+              }
+            </div>
+          } @else {
+            <div class="grid grid-cols-1 gap-3">
+              @for (e of modalItems(); track e['data'] + (e['usuario']?.nome || '')) {
+                <div class="border rounded-xl p-3">
+                  <div class="flex items-center justify-between">
+                    <div class="text-sm">
+                      <div class="font-semibold">Cliente: {{e['cliente']?.nome || '-'}} | Data: {{ formatDate(e['data']) }}</div>
+                      <div class="text-gray-700">Evento: {{ e['evento'] || '-' }}</div>
+                    </div>
+                    <span class="text-xs px-2 py-1 rounded-full" [ngClass]="e['confirmado'] ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'">{{ e['confirmado'] ? 'Confirmado' : 'Pendente' }}</span>
+                  </div>
+                  <div class="text-xs text-gray-500 mt-1">Usuário: {{ e['usuario']?.nomeCompleto || '-' }}</div>
+                </div>
+              }
+            </div>
+          }
+
+          @if (modalMeta(); as m) {
+            <div class="flex items-center justify-between pt-3">
+              <div class="text-sm text-gray-600">Página {{ m.page }} de {{ m.totalPages }} — {{ m.total }} registros</div>
+              <div class="flex gap-2">
+                <button class="px-3 py-1.5 border rounded" [disabled]="modalLoading() || m.page <= 1" (click)="prevPage()">Anterior</button>
+                <button class="px-3 py-1.5 border rounded" [disabled]="modalLoading() || m.page >= m.totalPages" (click)="nextPage()">Próxima</button>
+              </div>
+            </div>
+          }
+        }
+      </div>
     </ng-template>
   </ion-modal>
-
-</ion-content>
-
+</div>


### PR DESCRIPTION
## Summary
- fetch sales KPIs from API via new VendasService
- render interactive apex charts and lucide icons in dashboard
- add interfaces and dependencies for charts and icons

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9cf028048329a4b68fdeae6ab012