### PR TITLE
Melhora visual do dashboard e recarregamento de clientes

### DIFF
--- a/src/app/vendas-dashboard/vendas-dashboard.page.html
+++ b/src/app/vendas-dashboard/vendas-dashboard.page.html
@@ -51,11 +51,12 @@
       <ion-grid class="kpi-grid">
         <ion-row>
           <ion-col size="12" size-md="6" size-lg="3">
-            <ion-card (click)="openModal('novos')">
+            <ion-card class="kpi-card novos" (click)="openModal('novos')">
               <ion-card-header>
                 <ion-card-subtitle>Clientes Novos</ion-card-subtitle>
               </ion-card-header>
               <ion-card-content>
+                <ion-icon name="person-add-outline"></ion-icon>
                 <div class="kpi-value">{{ d.clientesNovosHoje }}</div>
                 <div class="kpi-desc">{{ selectedPeriod()==='hoje' ? 'hoje' : ('neste ' + selectedPeriod()) }}</div>
               </ion-card-content>
@@ -63,11 +64,12 @@
           </ion-col>
 
           <ion-col size="12" size-md="6" size-lg="3">
-            <ion-card (click)="openModal('atendidos')">
+            <ion-card class="kpi-card atendidos" (click)="openModal('atendidos')">
               <ion-card-header>
                 <ion-card-subtitle>Clientes Atendidos</ion-card-subtitle>
               </ion-card-header>
               <ion-card-content>
+                <ion-icon name="chatbubbles-outline"></ion-icon>
                 <div class="kpi-value">{{ d.clientesAtendidosHoje }}</div>
                 <div class="kpi-desc">{{ selectedPeriod()==='hoje' ? 'hoje' : ('neste ' + selectedPeriod()) }}</div>
               </ion-card-content>
@@ -75,11 +77,12 @@
           </ion-col>
 
           <ion-col size="12" size-md="6" size-lg="3">
-            <ion-card>
+            <ion-card class="kpi-card total">
               <ion-card-header>
                 <ion-card-subtitle>Total Cadastrados</ion-card-subtitle>
               </ion-card-header>
               <ion-card-content>
+                <ion-icon name="people-outline"></ion-icon>
                 <div class="kpi-value">{{ d.totalClientesCadastrados }}</div>
                 <div class="kpi-desc">clientes ativos</div>
               </ion-card-content>
@@ -87,11 +90,12 @@
           </ion-col>
 
           <ion-col size="12" size-md="6" size-lg="3">
-            <ion-card (click)="openModal('eventos')">
+            <ion-card class="kpi-card eventos" (click)="openModal('eventos')">
               <ion-card-header>
                 <ion-card-subtitle>Eventos Marcados</ion-card-subtitle>
               </ion-card-header>
               <ion-card-content>
+                <ion-icon name="calendar-outline"></ion-icon>
                 <div class="kpi-value">{{ d.eventosMarcados }}</div>
                 <div class="kpi-desc">Eventos marcados</div>
               </ion-card-content>
@@ -99,11 +103,12 @@
           </ion-col>
 
           <ion-col size="12" size-md="6" size-lg="3">
-            <ion-card (click)="openModal('fechados')">
+            <ion-card class="kpi-card fechados" (click)="openModal('fechados')">
               <ion-card-header>
                 <ion-card-subtitle>Fechados</ion-card-subtitle>
               </ion-card-header>
               <ion-card-content>
+                <ion-icon name="checkmark-done-outline"></ion-icon>
                 <div class="kpi-value">{{ d.clientesFechados }}</div>
                 <div class="kpi-desc">Vendas Fechadas</div>
               </ion-card-content>

--- a/src/app/vendas-dashboard/vendas-dashboard.page.scss
+++ b/src/app/vendas-dashboard/vendas-dashboard.page.scss
@@ -30,6 +30,37 @@
   text-align: center;
 }
 
+.kpi-card {
+  border-left: none;
+  border-top: 4px solid var(--card-color);
+}
+
+.kpi-card ion-icon {
+  font-size: 2rem;
+  color: var(--card-color);
+  margin-bottom: 0.5rem;
+}
+
+.kpi-card.novos {
+  --card-color: var(--ion-color-primary);
+}
+
+.kpi-card.atendidos {
+  --card-color: var(--ion-color-secondary);
+}
+
+.kpi-card.total {
+  --card-color: var(--ion-color-tertiary);
+}
+
+.kpi-card.eventos {
+  --card-color: var(--ion-color-warning);
+}
+
+.kpi-card.fechados {
+  --card-color: var(--ion-color-success);
+}
+
 .kpi-value {
   font-size: 1.5rem;
   font-weight: 700;

--- a/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
@@ -49,7 +49,6 @@ export class ListaClientesComponent implements OnInit {
   ngOnInit(): void {
     this.viewMode = this.viewPref.getViewMode();
     this.carregarFiltros();
-    this.fetch();
   }
 
   private buildParams(extra: any = {}) {

--- a/src/app/vendas-lista-clientes/vendas-lista-clientes.page.ts
+++ b/src/app/vendas-lista-clientes/vendas-lista-clientes.page.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import { Component, ViewChild } from '@angular/core';
+import { IonViewDidEnter, IonicModule } from '@ionic/angular';
 import { ListaClientesComponent } from './lista-clientes/lista-clientes.component';
 
 @Component({
@@ -8,4 +8,10 @@ import { ListaClientesComponent } from './lista-clientes/lista-clientes.componen
   standalone: true,
   imports: [IonicModule, ListaClientesComponent],
 })
-export class VendasListaClientesPage {}
+export class VendasListaClientesPage implements IonViewDidEnter {
+  @ViewChild(ListaClientesComponent) listaClientes!: ListaClientesComponent;
+
+  ionViewDidEnter(): void {
+    this.listaClientes.fetch();
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -45,3 +45,12 @@
   }
 }
 
+/* Detalhes em verde para os componentes padrão */
+ion-item {
+  --highlight-color-focused: var(--ion-color-success);
+}
+
+ion-card {
+  border-left: 4px solid var(--ion-color-success);
+}
+


### PR DESCRIPTION
## Summary
- add icons and color accents to dashboard cards
- style ionic components with green theme details
- reload client list when returning to the page

## Testing
- `npm run lint` (fails: Prefer using the inject() function, etc.)
- `npm test` (fails: No binary for Chrome browser on your platform)

------
https://chatgpt.com/codex/tasks/task_e_68ab968fc080832996a1d8d19986bfac