### PR TITLE
refactor: enhance client modal with events

### DIFF
--- a/src/app/services/clientes.service.ts
+++ b/src/app/services/clientes.service.ts
@@ -24,6 +24,15 @@ export interface ClientesResponse {
   meta: { total: number; totalPages: number };
 }
 
+export interface ClienteEvento {
+  idEvento: number;
+  idCliente: number;
+  data: string;
+  dataLocal?: string;
+  evento?: string | null;
+  confirmado?: boolean | null;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ClientesService {
   private http = inject(HttpClient);
@@ -42,5 +51,19 @@ export class ClientesService {
 
   getClientes(params: any): Observable<Cliente[]> {
     return this.http.get<Cliente[]>(this.api, { params });
+  }
+
+  getEventosDoCliente(idCliente: number, params: any = {}): Observable<ClienteEvento[]> {
+    return this.http.get<ClienteEvento[]>(`${this.api}/${idCliente}/eventos`, { params });
+  }
+
+  criarEvento(payload: {
+    idCliente: number;
+    idUsuario?: number;
+    data: string;
+    evento?: string | null;
+    tz?: string;
+  }): Observable<ClienteEvento> {
+    return this.http.post<ClienteEvento>(`${this.api}/eventos`, payload);
   }
 }

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.html
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.html
@@ -12,11 +12,34 @@
     </ion-header>
 
     <ion-content class="ion-padding" *ngIf="formData">
-      <div class="info-box">
-        <ion-text color="medium">Cadastrado por:</ion-text>
-        <h2>{{ formData.responsavel?.name || '-' }}</h2>
-      </div>
+      <!-- Informações fixas -->
+      <ion-card class="info-card">
+        <ion-card-content>
+          <ion-item lines="none">
+            <ion-icon slot="start" name="person-circle-outline"></ion-icon>
+            <ion-label>
+              <p>Cadastrado por</p>
+              <h2>{{ formData.responsavel?.name || '-' }}</h2>
+            </ion-label>
+          </ion-item>
+          <ion-item lines="none">
+            <ion-icon slot="start" name="calendar-outline" color="primary"></ion-icon>
+            <ion-label>
+              <p>Data de Criação</p>
+              <h3>{{ formData.created_at | date: 'dd/MM/yyyy HH:mm' }}</h3>
+            </ion-label>
+          </ion-item>
+          <ion-item lines="none">
+            <ion-icon slot="start" name="refresh-outline" color="success"></ion-icon>
+            <ion-label>
+              <p>Última Atualização</p>
+              <h3>{{ formData.updated_at | date: 'dd/MM/yyyy HH:mm' }}</h3>
+            </ion-label>
+          </ion-item>
+        </ion-card-content>
+      </ion-card>
 
+      <!-- Formulário de edição -->
       <ion-list lines="full">
         <ion-item>
           <ion-label position="stacked">Nome *</ion-label>
@@ -62,14 +85,51 @@
         </ion-item>
       </ion-list>
 
-      <ion-item lines="full">
-        <ion-label>Data de Criação</ion-label>
-        <ion-note slot="end">{{ formData.created_at | date: 'dd/MM/yyyy HH:mm' }}</ion-note>
-      </ion-item>
-      <ion-item lines="full">
-        <ion-label>Última Atualização</ion-label>
-        <ion-note slot="end">{{ formData.updated_at | date: 'dd/MM/yyyy HH:mm' }}</ion-note>
-      </ion-item>
+      <!-- Eventos -->
+      <ion-card class="ion-margin-top">
+        <ion-card-header>
+          <ion-card-title>Eventos do Cliente</ion-card-title>
+          <ion-card-subtitle>{{ eventos.length }} registro(s)</ion-card-subtitle>
+        </ion-card-header>
+        <ion-card-content>
+          <ion-item>
+            <ion-input placeholder="Título do evento" [(ngModel)]="evTitulo"></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-datetime presentation="date-time" [(ngModel)]="evData"></ion-datetime>
+          </ion-item>
+          <ion-button expand="block" (click)="marcarEvento()" [disabled]="isSavingEvento">
+            <ion-icon slot="start" name="calendar-outline"></ion-icon>
+            Marcar
+          </ion-button>
+        </ion-card-content>
+      </ion-card>
+
+      <ng-container *ngIf="eventos.length > 0">
+        <ion-card *ngFor="let ev of eventos" class="ion-margin-bottom">
+          <ion-item lines="none">
+            <ion-icon slot="start" name="time-outline"></ion-icon>
+            <ion-label>
+              <h2>{{ ev.dataLocal }}</h2>
+              <p>{{ ev.evento || 'Evento sem título' }}</p>
+            </ion-label>
+            <ion-badge slot="end" [color]="ev.confirmado === null ? 'warning' : ev.confirmado ? 'success' : 'danger'">
+              {{ ev.confirmado === null ? 'Pendente' : ev.confirmado ? 'Confirmado' : 'Cancelado' }}
+            </ion-badge>
+          </ion-item>
+          <ion-card-content>
+            <ion-button size="small" color="success" expand="block" *ngIf="ev.confirmado === null" (click)="confirmarEventoLocal(ev)">
+              <ion-icon slot="start" name="checkmark-circle-outline"></ion-icon>
+              Confirmar
+            </ion-button>
+            <ion-button size="small" color="medium" expand="block" *ngIf="ev.confirmado === null" (click)="cancelarEventoLocal(ev)">
+              <ion-icon slot="start" name="close-circle-outline"></ion-icon>
+              Cancelar
+            </ion-button>
+          </ion-card-content>
+        </ion-card>
+      </ng-container>
+      <ion-text color="medium" *ngIf="!isLoadingEventos && eventos.length === 0">Nenhum evento cadastrado.</ion-text>
 
       <div class="dias" *ngIf="formData.created_at">
         Criado há {{ calcularDias(formData.created_at) }} {{ calcularDias(formData.created_at) === 1 ? 'dia' : 'dias' }}

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.scss
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.scss
@@ -3,9 +3,8 @@
   --height: 80%; /* ou 600px */
 }
 
-.info-box {
-  text-align: center;
-  margin-bottom: 1rem;
+.info-card ion-item {
+  --padding-start: 0;
 }
 
 .dias {


### PR DESCRIPTION
## Summary
- showcase static client details in a highlighted card with icons
- add event creation and management to client modal
- expose client event endpoints in ClientesService

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Angular ESLint configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4ff25e483298223cf1c511a53a0