### PR TITLE
style(login): adjust input appearance

### DIFF
--- a/src/app/login/login.page.scss
+++ b/src/app/login/login.page.scss
@@ -38,31 +38,14 @@ ion-content {
     background: #fff;
     box-shadow: none;
   }
-
-  ion-input {
-    --padding-start: 12px;        /* agora controla o texto */
-    border: 1px solid #ccc;       /* opcional: dá “caixinha” */
-    border-radius: 6px;
-    background: #fff;             /* ou transparente */
-  }
   ion-button{
     margin-top: 20px;
   }
 }
 
-input{
-  background: #fff;          /* FUNDO branco */
-
-}
-
 ion-input.custom-input {
-  --background: #fff;          /* FUNDO branco */
   --color: #000;               /* texto preto */
   --placeholder-color: #666;   /* placeholder cinza */
-  --padding-start: 12px;
-  --padding-end: 12px;
-  --padding-top: 8px;
-  --padding-bottom: 8px;
 
   border: 1px solid #ccc;      /* borda externa */
   border-radius: 6px;
@@ -70,5 +53,11 @@ ion-input.custom-input {
 
   /* opcional: sombra leve */
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+ion-input.custom-input::part(native) {
+  background: #fff;            /* fundo branco */
+  padding-left: 12px;          /* desloca texto para direita */
+  padding-right: 12px;
 }
 


### PR DESCRIPTION
## Summary
- ensure login inputs use white background
- add padding for right-shifted text

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_e_68acfb5944d88329a9797082e9732640