### PR TITLE
feat: add subscription sign-up flow

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -14,6 +14,22 @@ const routes: Routes = [
     loadChildren: () => import('./login/login.module').then( m => m.LoginPageModule)
   },
   {
+    path: 'planos',
+    loadChildren: () => import('./planos/planos.module').then(m => m.PlanosPageModule)
+  },
+  {
+    path: 'cadastro',
+    loadChildren: () => import('./cadastro/cadastro.module').then(m => m.CadastroPageModule)
+  },
+  {
+    path: 'checkout',
+    loadChildren: () => import('./checkout/checkout.module').then(m => m.CheckoutPageModule)
+  },
+  {
+    path: 'confirmacao',
+    loadChildren: () => import('./confirmacao/confirmacao.module').then(m => m.ConfirmacaoPageModule)
+  },
+  {
     path: 'vendas/dashboard',
     loadComponent: () => import('./vendas-dashboard/vendas-dashboard.page').then(m => m.VendasDashboardPage),
     canActivate: [AuthGuard],

--- a/src/app/cadastro/cadastro-routing.module.ts
+++ b/src/app/cadastro/cadastro-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CadastroPage } from './cadastro.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CadastroPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CadastroPageRoutingModule {}

--- a/src/app/cadastro/cadastro.module.ts
+++ b/src/app/cadastro/cadastro.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { CadastroPageRoutingModule } from './cadastro-routing.module';
+import { CadastroPage } from './cadastro.page';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, IonicModule, CadastroPageRoutingModule],
+  declarations: [CadastroPage],
+})
+export class CadastroPageModule {}

--- a/src/app/cadastro/cadastro.page.html
+++ b/src/app/cadastro/cadastro.page.html
@@ -1,0 +1,20 @@
+<ion-content class="ion-padding">
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <ion-item>
+      <ion-input formControlName="empresa" placeholder="Nome da empresa"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input formControlName="emailEmpresa" type="email" placeholder="Email de contato"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input formControlName="adminNome" placeholder="Nome do administrador"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input formControlName="adminEmail" type="email" placeholder="Email do administrador"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input formControlName="senha" type="password" placeholder="Senha"></ion-input>
+    </ion-item>
+    <ion-button expand="full" type="submit">Continuar</ion-button>
+  </form>
+</ion-content>

--- a/src/app/cadastro/cadastro.page.scss
+++ b/src/app/cadastro/cadastro.page.scss
@@ -1,0 +1,1 @@
+/* estilos para cadastro */

--- a/src/app/cadastro/cadastro.page.ts
+++ b/src/app/cadastro/cadastro.page.ts
@@ -1,0 +1,63 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ToastController } from '@ionic/angular';
+import { switchMap } from 'rxjs';
+
+import { TenantService } from '../services/tenant.service';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-cadastro',
+  templateUrl: './cadastro.page.html',
+  styleUrls: ['./cadastro.page.scss'],
+})
+export class CadastroPage {
+  form: FormGroup;
+  private fb = inject(FormBuilder);
+  private tenant = inject(TenantService);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  private toast = inject(ToastController);
+
+  constructor() {
+    this.form = this.fb.group({
+      empresa: ['', Validators.required],
+      emailEmpresa: ['', [Validators.required, Validators.email]],
+      adminNome: ['', Validators.required],
+      adminEmail: ['', [Validators.required, Validators.email]],
+      senha: ['', Validators.required],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const value = this.form.value;
+    this.tenant
+      .createTenant({ name: value.empresa, email: value.emailEmpresa })
+      .pipe(
+        switchMap((tenant) =>
+          this.auth.register({
+            tenant_id: tenant.id,
+            email: value.adminEmail,
+            password: value.senha,
+            name: value.adminNome,
+          })
+        )
+      )
+      .subscribe({
+        next: () => this.router.navigate(['/checkout']),
+        error: async (error) => {
+          const message = error?.error?.error || 'Erro ao cadastrar.';
+          const toast = await this.toast.create({
+            message,
+            duration: 3000,
+            color: 'danger',
+          });
+          toast.present();
+        },
+      });
+  }
+}

--- a/src/app/checkout/checkout-routing.module.ts
+++ b/src/app/checkout/checkout-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CheckoutPage } from './checkout.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CheckoutPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CheckoutPageRoutingModule {}

--- a/src/app/checkout/checkout.module.ts
+++ b/src/app/checkout/checkout.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { CheckoutPageRoutingModule } from './checkout-routing.module';
+import { CheckoutPage } from './checkout.page';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, IonicModule, CheckoutPageRoutingModule],
+  declarations: [CheckoutPage],
+})
+export class CheckoutPageModule {}

--- a/src/app/checkout/checkout.page.html
+++ b/src/app/checkout/checkout.page.html
@@ -1,0 +1,16 @@
+<ion-content class="ion-padding">
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <ion-list>
+      <ion-radio-group formControlName="plan">
+        <ion-item *ngFor="let p of plans">
+          <ion-label>{{ p.label }}</ion-label>
+          <ion-radio slot="start" [value]="p.id"></ion-radio>
+        </ion-item>
+      </ion-radio-group>
+    </ion-list>
+    <ion-item>
+      <ion-input type="number" formControlName="seats" placeholder="Número de contas"></ion-input>
+    </ion-item>
+    <ion-button expand="full" type="submit">Ir para pagamento</ion-button>
+  </form>
+</ion-content>

--- a/src/app/checkout/checkout.page.scss
+++ b/src/app/checkout/checkout.page.scss
@@ -1,0 +1,1 @@
+/* estilos para checkout */

--- a/src/app/checkout/checkout.page.ts
+++ b/src/app/checkout/checkout.page.ts
@@ -1,0 +1,54 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import { BillingService } from '../services/billing.service';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-checkout',
+  templateUrl: './checkout.page.html',
+  styleUrls: ['./checkout.page.scss'],
+})
+export class CheckoutPage {
+  form: FormGroup;
+  private fb = inject(FormBuilder);
+  private billing = inject(BillingService);
+  private auth = inject(AuthService);
+
+  plans = [
+    { id: 'starter', label: '1 conta', priceId: 'price_starter' },
+    { id: 'team', label: '2 até 3 contas', priceId: 'price_team' },
+    { id: 'medium', label: '4 até 5 contas', priceId: 'price_medium' },
+    { id: 'large', label: '6+ contas', priceId: 'price_large' },
+  ];
+
+  constructor() {
+    this.form = this.fb.group({
+      plan: [this.plans[0].id, Validators.required],
+      seats: [1, [Validators.required, Validators.min(1)]],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const value = this.form.value;
+    const tenant_id = this.auth.getTenantId();
+    if (!tenant_id) {
+      return;
+    }
+    const price = this.plans.find((p) => p.id === value.plan)!;
+    this.billing
+      .checkout({
+        tenant_id,
+        price_id: price.priceId,
+        seatCountInicial: value.seats,
+        success_url: `${window.location.origin}/confirmacao`,
+        cancel_url: `${window.location.origin}/checkout`,
+      })
+      .subscribe((res) => {
+        window.location.href = res.checkout_url;
+      });
+  }
+}

--- a/src/app/confirmacao/confirmacao-routing.module.ts
+++ b/src/app/confirmacao/confirmacao-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ConfirmacaoPage } from './confirmacao.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ConfirmacaoPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ConfirmacaoPageRoutingModule {}

--- a/src/app/confirmacao/confirmacao.module.ts
+++ b/src/app/confirmacao/confirmacao.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { ConfirmacaoPageRoutingModule } from './confirmacao-routing.module';
+import { ConfirmacaoPage } from './confirmacao.page';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, ConfirmacaoPageRoutingModule],
+  declarations: [ConfirmacaoPage],
+})
+export class ConfirmacaoPageModule {}

--- a/src/app/confirmacao/confirmacao.page.html
+++ b/src/app/confirmacao/confirmacao.page.html
@@ -1,0 +1,8 @@
+<ion-content class="ion-padding">
+  <div *ngIf="status">
+    <h2>Pagamento confirmado!</h2>
+    <p>Status: {{ status.status_billing }}</p>
+    <ion-button expand="block" (click)="goToUsuarios()">Cadastrar mais usuários</ion-button>
+    <ion-button expand="block" color="success" (click)="goToSistema()">Ir para o sistema</ion-button>
+  </div>
+</ion-content>

--- a/src/app/confirmacao/confirmacao.page.scss
+++ b/src/app/confirmacao/confirmacao.page.scss
@@ -1,0 +1,1 @@
+/* estilos para confirmacao */

--- a/src/app/confirmacao/confirmacao.page.ts
+++ b/src/app/confirmacao/confirmacao.page.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { BillingService } from '../services/billing.service';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-confirmacao',
+  templateUrl: './confirmacao.page.html',
+  styleUrls: ['./confirmacao.page.scss'],
+})
+export class ConfirmacaoPage implements OnInit {
+  status: any;
+  private billing = inject(BillingService);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+
+  ngOnInit() {
+    const tenantId = this.auth.getTenantId();
+    if (tenantId) {
+      this.billing.getStatus(tenantId).subscribe((res) => {
+        this.status = res;
+      });
+    }
+  }
+
+  goToUsuarios() {
+    this.router.navigate(['/usuarios/novo']);
+  }
+
+  goToSistema() {
+    this.router.navigate(['/vendas/dashboard']);
+  }
+}

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -23,6 +23,8 @@
       <ion-button expand="full" type="submit">Entrar</ion-button>
     </form>
 
+    <ion-button expand="full" fill="outline" routerLink="/planos">Planos</ion-button>
+
   </div>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">

--- a/src/app/planos/planos-routing.module.ts
+++ b/src/app/planos/planos-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PlanosPage } from './planos.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PlanosPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PlanosPageRoutingModule {}

--- a/src/app/planos/planos.module.ts
+++ b/src/app/planos/planos.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { PlanosPageRoutingModule } from './planos-routing.module';
+import { PlanosPage } from './planos.page';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, PlanosPageRoutingModule],
+  declarations: [PlanosPage],
+})
+export class PlanosPageModule {}

--- a/src/app/planos/planos.page.html
+++ b/src/app/planos/planos.page.html
@@ -1,0 +1,16 @@
+<ion-content class="ion-padding">
+  <h1>7 dias grátis</h1>
+  <p>O Converto custa de 0 na primeira semana. Veja os planos:</p>
+
+  <ion-card *ngFor="let plan of plans">
+    <ion-card-header>
+      <ion-card-title>{{ plan.title }}</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p>{{ plan.description }}</p>
+      <strong>{{ plan.price }}</strong>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-button expand="block" (click)="começar()">Começar agora</ion-button>
+</ion-content>

--- a/src/app/planos/planos.page.scss
+++ b/src/app/planos/planos.page.scss
@@ -1,0 +1,1 @@
+/* estilos específicos para planos */

--- a/src/app/planos/planos.page.ts
+++ b/src/app/planos/planos.page.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+interface Plan {
+  title: string;
+  description: string;
+  price: string;
+}
+
+@Component({
+  selector: 'app-planos',
+  templateUrl: './planos.page.html',
+  styleUrls: ['./planos.page.scss'],
+})
+export class PlanosPage {
+  plans: Plan[] = [
+    { title: '1 conta', description: 'Plano starter para teste e gerencia de uma pessoa só', price: 'R$29,90' },
+    { title: '2 até 3 contas', description: 'Para equipes de vendas', price: 'R$23,00 por conta' },
+    { title: '4 até 5 contas', description: 'Para empresas médias', price: 'R$26,00 por conta' },
+    { title: '6+ contas', description: 'Para empresas grandes', price: 'R$30,00 por conta' },
+  ];
+
+  constructor(private router: Router) {}
+
+  começar(): void {
+    this.router.navigate(['/cadastro']);
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -31,6 +31,22 @@ export class AuthService {
       );
   }
 
+  register(data: {
+    tenant_id: string;
+    email: string;
+    password: string;
+    name: string;
+  }): Observable<{ token: string }> {
+    return this.http
+      .post<{ token: string }>(`${environment.apiUrl}/auth/register`, data)
+      .pipe(
+        tap((res) => {
+          this.token$.next(res.token);
+          localStorage.setItem('token', res.token);
+        })
+      );
+  }
+
   get token(): string | null {
     return this.token$.value;
   }

--- a/src/app/services/billing.service.ts
+++ b/src/app/services/billing.service.ts
@@ -8,6 +8,16 @@ export class BillingService {
   private http = inject(HttpClient);
   private api = `${environment.apiUrl}/billing`;
 
+  checkout(data: {
+    tenant_id: string;
+    price_id: string;
+    seatCountInicial: number;
+    success_url: string;
+    cancel_url: string;
+  }): Observable<any> {
+    return this.http.post<any>(`${this.api}/checkout`, data);
+  }
+
   getStatus(tenantId: string): Observable<any> {
     return this.http.get<any>(`${this.api}/status/${tenantId}`);
   }

--- a/src/app/services/tenant.service.ts
+++ b/src/app/services/tenant.service.ts
@@ -8,6 +8,10 @@ export class TenantService {
   private http = inject(HttpClient);
   private api = `${environment.apiUrl}/tenants`;
 
+  createTenant(data: { name: string; email: string; enterprise_name?: string }): Observable<any> {
+    return this.http.post<any>(this.api, data);
+  }
+
   getTenant(id: string): Observable<any> {
     return this.http.get<any>(`${this.api}/${id}`);
   }


### PR DESCRIPTION
## Summary
- add Planos button and route from login
- create plan selection, company sign-up, checkout, and confirmation pages
- extend auth, tenant and billing services for onboarding

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e219fb88329b3e63d846314d047