### PR TITLE
refactor: standardize components to module-based structure

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -31,61 +31,61 @@ const routes: Routes = [
   },
   {
     path: 'vendas/dashboard',
-    loadComponent: () => import('./vendas-dashboard/vendas-dashboard.page').then(m => m.VendasDashboardPage),
+    loadChildren: () => import('./vendas-dashboard/vendas-dashboard.module').then(m => m.VendasDashboardPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Relatório de Atendimento' }
   },
   {
     path: 'vendas/leads',
-    loadComponent: () => import('./vendas-leads/vendas-leads.page').then(m => m.VendasLeadsPage),
+    loadChildren: () => import('./vendas-leads/vendas-leads.module').then(m => m.VendasLeadsPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Cadastrar Clientes' }
   },
   {
     path: 'vendas/lista/clientes',
-    loadComponent: () => import('./vendas-lista-clientes/vendas-lista-clientes.page').then(m => m.VendasListaClientesPage),
+    loadChildren: () => import('./vendas-lista-clientes/vendas-lista-clientes.module').then(m => m.VendasListaClientesPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Lista de Clientes' }
   },
   {
     path: 'ref',
-    loadComponent: () => import('./ref/ref.page').then(m => m.RefPage),
+    loadChildren: () => import('./ref/ref.module').then(m => m.RefPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Usuários' }
   },
   {
     path: 'setores',
-    loadComponent: () => import('./setores/setores.page').then(m => m.SetoresPage),
+    loadChildren: () => import('./setores/setores.module').then(m => m.SetoresPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Setores' }
   },
   {
     path: 'usuarios/novo',
-    loadComponent: () => import('./usuarios-novo/usuarios-novo.page').then(m => m.UsuariosNovoPage),
+    loadChildren: () => import('./usuarios-novo/usuarios-novo.module').then(m => m.UsuariosNovoPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Novo Usuário' }
   },
   {
     path: 'perfil',
-    loadComponent: () => import('./perfil/perfil.page').then(m => m.PerfilPage),
+    loadChildren: () => import('./perfil/perfil.module').then(m => m.PerfilPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Perfil' }
   },
   {
     path: 'empresa',
-    loadComponent: () => import('./empresa/empresa.page').then(m => m.EmpresaPage),
+    loadChildren: () => import('./empresa/empresa.module').then(m => m.EmpresaPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Empresa' }
   },
   {
     path: 'assentos',
-    loadComponent: () => import('./assentos/assentos.page').then(m => m.AssentosPage),
+    loadChildren: () => import('./assentos/assentos.module').then(m => m.AssentosPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Assentos' }
   },
   {
     path: 'configuracoes',
-    loadComponent: () => import('./configuracoes/configuracoes.page').then(m => m.ConfiguracoesPage),
+    loadChildren: () => import('./configuracoes/configuracoes.module').then(m => m.ConfiguracoesPageModule),
     canActivate: [AuthGuard],
     data: { title: 'Configurações' }
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,11 +11,11 @@ import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { AuthInterceptor } from './interceptors/auth.interceptor';
 import { NavMenuComponent } from './nav-menu/nav-menu.component';
-import { HeaderComponent } from './components/header/header.component';
+import { ComponentsModule } from './components/components.module';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, HeaderComponent],
-  imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule,
+  declarations: [AppComponent, NavMenuComponent],
+  imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],
   providers: [

--- a/src/app/assentos/assentos-routing.module.ts
+++ b/src/app/assentos/assentos-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AssentosPage } from './assentos.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AssentosPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AssentosPageRoutingModule {}
+

--- a/src/app/assentos/assentos.module.ts
+++ b/src/app/assentos/assentos.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { AssentosPageRoutingModule } from './assentos-routing.module';
+import { AssentosPage } from './assentos.page';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, AssentosPageRoutingModule],
+  declarations: [AssentosPage],
+})
+export class AssentosPageModule {}
+

--- a/src/app/assentos/assentos.page.ts
+++ b/src/app/assentos/assentos.page.ts
@@ -1,15 +1,11 @@
 import { Component, inject } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
-import { FormsModule } from '@angular/forms';
 import { SeatsService } from '../services/seats.service';
 import { AuthService } from '../services/auth.service';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-assentos',
   templateUrl: './assentos.page.html',
-  standalone: true,
-  imports: [IonicModule, FormsModule, CommonModule],
+  standalone: false,
 })
 export class AssentosPage {
   private seats = inject(SeatsService);

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { HeaderComponent } from './header/header.component';
+import { GearBackgroundComponent } from './gear-background/gear-background.component';
+
+@NgModule({
+  declarations: [HeaderComponent, GearBackgroundComponent],
+  imports: [CommonModule, IonicModule],
+  exports: [HeaderComponent, GearBackgroundComponent],
+})
+export class ComponentsModule {}
+

--- a/src/app/configuracoes/configuracoes-routing.module.ts
+++ b/src/app/configuracoes/configuracoes-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ConfiguracoesPage } from './configuracoes.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ConfiguracoesPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ConfiguracoesPageRoutingModule {}
+

--- a/src/app/configuracoes/configuracoes.module.ts
+++ b/src/app/configuracoes/configuracoes.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { ConfiguracoesPageRoutingModule } from './configuracoes-routing.module';
+import { ConfiguracoesPage } from './configuracoes.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ConfiguracoesPageRoutingModule],
+  declarations: [ConfiguracoesPage],
+})
+export class ConfiguracoesPageModule {}
+

--- a/src/app/configuracoes/configuracoes.page.ts
+++ b/src/app/configuracoes/configuracoes.page.ts
@@ -1,12 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
 import { ThemeService } from '../services/theme.service';
 
 @Component({
   selector: 'app-configuracoes',
   templateUrl: './configuracoes.page.html',
-  standalone: true,
-  imports: [IonicModule],
+  standalone: false,
 })
 export class ConfiguracoesPage {
   theme = inject(ThemeService);

--- a/src/app/empresa/empresa-routing.module.ts
+++ b/src/app/empresa/empresa-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { EmpresaPage } from './empresa.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: EmpresaPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class EmpresaPageRoutingModule {}
+

--- a/src/app/empresa/empresa.module.ts
+++ b/src/app/empresa/empresa.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { EmpresaPageRoutingModule } from './empresa-routing.module';
+import { EmpresaPage } from './empresa.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ReactiveFormsModule, EmpresaPageRoutingModule],
+  declarations: [EmpresaPage],
+})
+export class EmpresaPageModule {}
+

--- a/src/app/empresa/empresa.page.ts
+++ b/src/app/empresa/empresa.page.ts
@@ -1,13 +1,12 @@
 import { Component, inject } from '@angular/core';
-import { IonicModule, AlertController } from '@ionic/angular';
-import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { AlertController } from '@ionic/angular';
+import { FormBuilder } from '@angular/forms';
 import { EnterpriseService, Enterprise } from '../services/enterprise.service';
 
 @Component({
   selector: 'app-empresa',
   templateUrl: './empresa.page.html',
-  standalone: true,
-  imports: [IonicModule, ReactiveFormsModule],
+  standalone: false,
 })
 export class EmpresaPage {
   private service = inject(EnterpriseService);

--- a/src/app/perfil/perfil-routing.module.ts
+++ b/src/app/perfil/perfil-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PerfilPage } from './perfil.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PerfilPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PerfilPageRoutingModule {}
+

--- a/src/app/perfil/perfil.module.ts
+++ b/src/app/perfil/perfil.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { PerfilPageRoutingModule } from './perfil-routing.module';
+import { PerfilPage } from './perfil.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ReactiveFormsModule, PerfilPageRoutingModule],
+  declarations: [PerfilPage],
+})
+export class PerfilPageModule {}
+

--- a/src/app/perfil/perfil.page.ts
+++ b/src/app/perfil/perfil.page.ts
@@ -1,15 +1,13 @@
 import { Component, inject } from '@angular/core';
-import { IonicModule, AlertController } from '@ionic/angular';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { AlertController } from '@ionic/angular';
+import { FormBuilder } from '@angular/forms';
 import { ProfileService, Profile } from '../services/profile.service';
 
 @Component({
   selector: 'app-perfil',
   templateUrl: './perfil.page.html',
   styleUrls: ['./perfil.page.scss'],
-  standalone: true,
-  imports: [IonicModule, CommonModule, ReactiveFormsModule],
+  standalone: false,
 })
 export class PerfilPage {
   private profileService = inject(ProfileService);

--- a/src/app/ref/ref-routing.module.ts
+++ b/src/app/ref/ref-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { RefPage } from './ref.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: RefPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class RefPageRoutingModule {}
+

--- a/src/app/ref/ref.module.ts
+++ b/src/app/ref/ref.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { RefPageRoutingModule } from './ref-routing.module';
+import { RefPage } from './ref.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, RefPageRoutingModule],
+  declarations: [RefPage],
+})
+export class RefPageModule {}
+

--- a/src/app/ref/ref.page.ts
+++ b/src/app/ref/ref.page.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
 
 @Component({
   selector: 'app-ref',
   templateUrl: './ref.page.html',
-  standalone: true,
-  imports: [IonicModule],
+  standalone: false,
 })
 export class RefPage {}

--- a/src/app/setores/setores-routing.module.ts
+++ b/src/app/setores/setores-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SetoresPage } from './setores.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SetoresPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SetoresPageRoutingModule {}
+

--- a/src/app/setores/setores.module.ts
+++ b/src/app/setores/setores.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { SetoresPageRoutingModule } from './setores-routing.module';
+import { SetoresPage } from './setores.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, SetoresPageRoutingModule],
+  declarations: [SetoresPage],
+})
+export class SetoresPageModule {}
+

--- a/src/app/setores/setores.page.ts
+++ b/src/app/setores/setores.page.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
 
 @Component({
   selector: 'app-setores',
   templateUrl: './setores.page.html',
-  standalone: true,
-  imports: [IonicModule],
+  standalone: false,
 })
 export class SetoresPage {}

--- a/src/app/usuarios-novo/usuarios-novo-routing.module.ts
+++ b/src/app/usuarios-novo/usuarios-novo-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { UsuariosNovoPage } from './usuarios-novo.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: UsuariosNovoPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class UsuariosNovoPageRoutingModule {}
+

--- a/src/app/usuarios-novo/usuarios-novo.module.ts
+++ b/src/app/usuarios-novo/usuarios-novo.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { UsuariosNovoPageRoutingModule } from './usuarios-novo-routing.module';
+import { UsuariosNovoPage } from './usuarios-novo.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, UsuariosNovoPageRoutingModule],
+  declarations: [UsuariosNovoPage],
+})
+export class UsuariosNovoPageModule {}
+

--- a/src/app/usuarios-novo/usuarios-novo.page.ts
+++ b/src/app/usuarios-novo/usuarios-novo.page.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
 
 @Component({
   selector: 'app-usuarios-novo',
   templateUrl: './usuarios-novo.page.html',
-  standalone: true,
-  imports: [IonicModule],
+  standalone: false,
 })
 export class UsuariosNovoPage {}

--- a/src/app/vendas-dashboard/vendas-dashboard-routing.module.ts
+++ b/src/app/vendas-dashboard/vendas-dashboard-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VendasDashboardPage } from './vendas-dashboard.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: VendasDashboardPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class VendasDashboardPageRoutingModule {}
+

--- a/src/app/vendas-dashboard/vendas-dashboard.module.ts
+++ b/src/app/vendas-dashboard/vendas-dashboard.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { NgApexchartsModule } from 'ng-apexcharts';
+
+import { VendasDashboardPageRoutingModule } from './vendas-dashboard-routing.module';
+import { VendasDashboardPage } from './vendas-dashboard.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, NgApexchartsModule, VendasDashboardPageRoutingModule],
+  declarations: [VendasDashboardPage],
+})
+export class VendasDashboardPageModule {}
+

--- a/src/app/vendas-dashboard/vendas-dashboard.page.ts
+++ b/src/app/vendas-dashboard/vendas-dashboard.page.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
 import { VendasService } from 'src/app/services/vendas/vendas.service';
 import { IDashboardVendas } from 'src/app/interfaces/IDashboardVendas';
 import {
@@ -16,8 +14,6 @@ import {
   ApexLegend,
   ApexResponsive,
 } from 'ng-apexcharts';
-import { NgApexchartsModule } from 'ng-apexcharts';
-import { LucideAngularModule } from 'lucide-angular';
 
 
 
@@ -58,13 +54,7 @@ type ModalKind = 'novos' | 'atendidos' | 'fechados' | 'eventos' | null;
   selector: 'app-vendas-dashboard',
   templateUrl: './vendas-dashboard.page.html',
   styleUrls: ['./vendas-dashboard.page.scss'],
-  standalone: true,
-  imports: [
-    IonicModule,
-    CommonModule,
-    NgApexchartsModule,
-    LucideAngularModule,
-  ],
+  standalone: false,
 })
 export class VendasDashboardPage implements OnInit {
   data = signal<IDashboardVendas | null>(null);

--- a/src/app/vendas-leads/vendas-leads-routing.module.ts
+++ b/src/app/vendas-leads/vendas-leads-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VendasLeadsPage } from './vendas-leads.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: VendasLeadsPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class VendasLeadsPageRoutingModule {}
+

--- a/src/app/vendas-leads/vendas-leads.module.ts
+++ b/src/app/vendas-leads/vendas-leads.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { VendasLeadsPageRoutingModule } from './vendas-leads-routing.module';
+import { VendasLeadsPage } from './vendas-leads.page';
+import { SharedDirectivesModule } from 'src/shared/shared-directives.module';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ReactiveFormsModule, SharedDirectivesModule, VendasLeadsPageRoutingModule],
+  declarations: [VendasLeadsPage],
+})
+export class VendasLeadsPageModule {}
+

--- a/src/app/vendas-leads/vendas-leads.page.ts
+++ b/src/app/vendas-leads/vendas-leads.page.ts
@@ -1,18 +1,14 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { IonicModule, AlertController } from '@ionic/angular';
-import { FormBuilder, Validators, ReactiveFormsModule, AbstractControl, ValidationErrors } from '@angular/forms';
+import { AlertController, IonSelect } from '@ionic/angular';
+import { FormBuilder, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
 import { ClientesService } from '../services/clientes.service';
 import { AuthService } from '../services/auth.service';
-import { IonSelect } from '@ionic/angular';
-import { CommonModule } from '@angular/common';
-import { SharedDirectivesModule } from 'src/shared/shared-directives.module';
 
 @Component({
   selector: 'app-vendas-leads',
   templateUrl: './vendas-leads.page.html',
   styleUrls: ['./vendas-leads.page.scss'],
-  standalone: true,
-  imports: [IonicModule, ReactiveFormsModule, CommonModule, SharedDirectivesModule],
+  standalone: false,
 })
 export class VendasLeadsPage implements OnInit {
   private fb = inject(FormBuilder);

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-card/cliente-card.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-card/cliente-card.component.ts
@@ -1,14 +1,11 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
 import { ClientesService, Cliente } from '../../../services/clientes.service';
 
 @Component({
   selector: 'app-cliente-card',
   templateUrl: './cliente-card.component.html',
   styleUrls: ['./cliente-card.component.scss'],
-  standalone: true,
-  imports: [IonicModule, CommonModule]
+  standalone: false,
 })
 export class ClienteCardComponent implements OnInit, OnChanges {
   @Input() cliente!: Cliente;

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.ts
@@ -1,7 +1,4 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
-import { FormsModule } from '@angular/forms';
 import { Cliente, ClientesService, ClienteEvento } from '../../../services/clientes.service';
 import { VendasService } from '../../../services/vendas/vendas.service';
 
@@ -9,8 +6,7 @@ import { VendasService } from '../../../services/vendas/vendas.service';
   selector: 'app-cliente-modal',
   templateUrl: './cliente-modal.component.html',
   styleUrls: ['./cliente-modal.component.scss'],
-  standalone: true,
-  imports: [IonicModule, CommonModule, FormsModule],
+  standalone: false,
 })
 export class ClienteModalComponent implements OnChanges {
   @Input() cliente!: Cliente | null;

--- a/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
@@ -1,19 +1,14 @@
 import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
-import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
-import { ClientesService, Cliente, ClientesResponse } from '../../services/clientes.service';
+import { FormControl } from '@angular/forms';
+import { ClientesService, Cliente } from '../../services/clientes.service';
 import { AuthService } from '../../services/auth.service';
-import { ClienteCardComponent } from './cliente-card/cliente-card.component';
-import { ClienteModalComponent } from './cliente-modal/cliente-modal.component';
 import { ViewPreferenceService } from '../../services/view-preference.service';
 
 @Component({
   selector: 'app-lista-clientes',
   templateUrl: './lista-clientes.component.html',
   styleUrls: ['./lista-clientes.component.scss'],
-  standalone: true,
-  imports: [IonicModule, CommonModule, FormsModule, ReactiveFormsModule, ClienteCardComponent, ClienteModalComponent]
+  standalone: false,
 })
 export class ListaClientesComponent implements OnInit {
   clientes: Cliente[] = [];

--- a/src/app/vendas-lista-clientes/vendas-lista-clientes-routing.module.ts
+++ b/src/app/vendas-lista-clientes/vendas-lista-clientes-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VendasListaClientesPage } from './vendas-lista-clientes.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: VendasListaClientesPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class VendasListaClientesPageRoutingModule {}
+

--- a/src/app/vendas-lista-clientes/vendas-lista-clientes.module.ts
+++ b/src/app/vendas-lista-clientes/vendas-lista-clientes.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+
+import { VendasListaClientesPageRoutingModule } from './vendas-lista-clientes-routing.module';
+import { VendasListaClientesPage } from './vendas-lista-clientes.page';
+import { ListaClientesComponent } from './lista-clientes/lista-clientes.component';
+import { ClienteModalComponent } from './lista-clientes/cliente-modal/cliente-modal.component';
+import { ClienteCardComponent } from './lista-clientes/cliente-card/cliente-card.component';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, IonicModule, VendasListaClientesPageRoutingModule],
+  declarations: [
+    VendasListaClientesPage,
+    ListaClientesComponent,
+    ClienteModalComponent,
+    ClienteCardComponent,
+  ],
+})
+export class VendasListaClientesPageModule {}
+

--- a/src/app/vendas-lista-clientes/vendas-lista-clientes.page.ts
+++ b/src/app/vendas-lista-clientes/vendas-lista-clientes.page.ts
@@ -1,12 +1,11 @@
 import { Component, ViewChild } from '@angular/core';
-import { ViewDidEnter , IonicModule } from '@ionic/angular';
+import { ViewDidEnter } from '@ionic/angular';
 import { ListaClientesComponent } from './lista-clientes/lista-clientes.component';
 
 @Component({
   selector: 'app-vendas-lista-clientes',
   templateUrl: './vendas-lista-clientes.page.html',
-  standalone: true,
-  imports: [IonicModule, ListaClientesComponent],
+  standalone: false,
 })
 export class VendasListaClientesPage implements ViewDidEnter  {
   @ViewChild(ListaClientesComponent) listaClientes!: ListaClientesComponent;


### PR DESCRIPTION
## Summary
- refactor components to use module-based architecture instead of standalone
- add feature modules and shared `ComponentsModule`
- update routing to lazy-load the new modules

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68af0790289c8329884c0ea666fea5b5