### PR TITLE
feat: add suporte page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { EmpresaPage } from './empresa/empresa.page';
 import { AssentosPage } from './assentos/assentos.page';
 import { ConfiguracoesPage } from './configuracoes/configuracoes.page';
 import { FolderPage } from './folder/folder.page';
+import { SuportePage } from './suporte/suporte.page';
 
 const routes: Routes = [
   {
@@ -83,6 +84,12 @@ const routes: Routes = [
     component: ConfiguracoesPage,
     canActivate: [AuthGuard],
     data: { title: 'Configurações' }
+  },
+  {
+    path: 'suporte',
+    component: SuportePage,
+    canActivate: [AuthGuard],
+    data: { title: 'Suporte' }
   },
   {
     path: 'folder/:id',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,9 +27,10 @@ import { FolderPage } from './folder/folder.page';
 import { ListaClientesComponent } from './vendas-lista-clientes/lista-clientes/lista-clientes.component';
 import { ClienteModalComponent } from './vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component';
 import { ClienteCardComponent } from './vendas-lista-clientes/lista-clientes/cliente-card/cliente-card.component';
+import { SuportePage } from './suporte/suporte.page';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, RefPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, AssentosPage, ConfiguracoesPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent],
+  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, RefPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, AssentosPage, ConfiguracoesPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage],
   imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule, FormsModule, ReactiveFormsModule, NgApexchartsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],

--- a/src/app/nav-menu/nav-menu.component.html
+++ b/src/app/nav-menu/nav-menu.component.html
@@ -42,6 +42,10 @@
       <ion-icon slot="start" name="settings"></ion-icon>
       <ion-label>Configurações</ion-label>
     </ion-item>
+    <ion-item routerLink="/suporte" lines="none" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+      <ion-icon slot="start" name="help-circle"></ion-icon>
+      <ion-label>Suporte</ion-label>
+    </ion-item>
     <ion-item lines="none" (click)="logout()">
       <ion-icon slot="start" name="log-out"></ion-icon>
       <ion-label>Sair</ion-label>

--- a/src/app/suporte/suporte.page.html
+++ b/src/app/suporte/suporte.page.html
@@ -1,0 +1,49 @@
+<ion-content class="ion-padding">
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>
+        <ion-icon name="help-circle-outline" slot="start"></ion-icon>
+        Contato
+      </ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-item>
+        <ion-icon name="mail-outline" slot="start"></ion-icon>
+        <ion-label>{{ email }}</ion-label>
+        <ion-button fill="clear" slot="end" (click)="copyEmail()">
+          <ion-icon name="copy-outline"></ion-icon>
+        </ion-button>
+      </ion-item>
+      <ion-item>
+        <ion-icon name="logo-whatsapp" slot="start"></ion-icon>
+        <ion-label>+55 99 9999-9999</ion-label>
+        <ion-button slot="end" (click)="openWhatsApp()">Entrar em contato</ion-button>
+      </ion-item>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Sugestões e Reportes</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p>Envie suas sugestões ou reporte bugs para melhorar o Converto.</p>
+      <form [formGroup]="form" (ngSubmit)="submit()">
+        <ion-item>
+          <ion-label position="stacked">Tipo</ion-label>
+          <ion-select formControlName="type">
+            <ion-select-option value="Comentário">Comentário</ion-select-option>
+            <ion-select-option value="Bug">Bug</ion-select-option>
+            <ion-select-option value="Sugestão">Sugestão</ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">Mensagem</ion-label>
+          <ion-textarea formControlName="message" autoGrow="true" [maxlength]="800" counter="true"></ion-textarea>
+        </ion-item>
+        <ion-button type="submit" expand="block">Enviar</ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
+</ion-content>
+

--- a/src/app/suporte/suporte.page.ts
+++ b/src/app/suporte/suporte.page.ts
@@ -1,0 +1,32 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-suporte',
+  templateUrl: './suporte.page.html',
+  standalone: false,
+})
+export class SuportePage {
+  private fb = inject(FormBuilder);
+
+  readonly email = 'suporte@converto.com';
+  readonly whatsapp = '5599999999999';
+
+  form = this.fb.group({
+    type: ['Comentário'],
+    message: ['', Validators.maxLength(800)],
+  });
+
+  copyEmail(): void {
+    navigator.clipboard.writeText(this.email);
+  }
+
+  openWhatsApp(): void {
+    window.open(`https://wa.me/${this.whatsapp}`, '_blank');
+  }
+
+  submit(): void {
+    // no action for now
+  }
+}
+


### PR DESCRIPTION
## Summary
- add support page with contact info and suggestion form
- wire support screen into routing and menu

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*
- `CHROME_BIN=/usr/bin/chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af730b61248329bce397f3ab913b15