### PR TITLE
feat: manage tenant users

### DIFF
--- a/src/app/services/profile.service.ts
+++ b/src/app/services/profile.service.ts
@@ -8,6 +8,7 @@ export interface Profile {
   email: string;
   name: string;
   role: string;
+  principal?: boolean;
   tenant?: { id: number; name: string } | null;
   enterprise?: { id: number; name: string } | null;
   seats?: {

--- a/src/app/services/usuarios.service.ts
+++ b/src/app/services/usuarios.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Usuario {
+  id?: number;
+  user_id?: number;
+  email: string;
+  name: string;
+  role: string;
+  tenant_id?: number;
+  principal?: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsuariosService {
+  private http = inject(HttpClient);
+  private api = `${environment.apiUrl}/usuarios`;
+
+  create(email: string, password: string, name: string): Observable<Usuario> {
+    return this.http.post<Usuario>(this.api, { email, password, name });
+  }
+
+  changeRole(id: number | string, role: string): Observable<{ id: number; role: string }> {
+    return this.http.patch<{ id: number; role: string }>(`${this.api}/${id}/role`, { role });
+  }
+}

--- a/src/app/usuarios-novo/usuarios-novo.page.html
+++ b/src/app/usuarios-novo/usuarios-novo.page.html
@@ -1,3 +1,24 @@
 <ion-content class="ion-padding">
-  <h1>Novo Usuário</h1>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Novo Usuário</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <form (ngSubmit)="create()">
+        <ion-item>
+          <ion-label position="floating">Nome</ion-label>
+          <ion-input name="name" [(ngModel)]="name" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="floating">Email</ion-label>
+          <ion-input type="email" name="email" [(ngModel)]="email" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="floating">Senha</ion-label>
+          <ion-input type="password" name="password" [(ngModel)]="password" required></ion-input>
+        </ion-item>
+        <ion-button expand="block" type="submit">Criar</ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
 </ion-content>

--- a/src/app/usuarios-novo/usuarios-novo.page.ts
+++ b/src/app/usuarios-novo/usuarios-novo.page.ts
@@ -1,8 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { UsuariosService } from '../services/usuarios.service';
 
 @Component({
   selector: 'app-usuarios-novo',
   templateUrl: './usuarios-novo.page.html',
   standalone: false,
 })
-export class UsuariosNovoPage {}
+export class UsuariosNovoPage {
+  private usuarios = inject(UsuariosService);
+  private router = inject(Router);
+
+  name = '';
+  email = '';
+  password = '';
+
+  create(): void {
+    this.usuarios.create(this.email, this.password, this.name).subscribe(() => {
+      this.router.navigate(['/usuarios']);
+    });
+  }
+}

--- a/src/app/usuarios/usuarios.page.html
+++ b/src/app/usuarios/usuarios.page.html
@@ -24,14 +24,21 @@
     <ion-card-content>
       <ion-grid class="table-view">
         <ion-row class="table-header">
-          <ion-col size="5">Usuário</ion-col>
-          <ion-col size="5">Email</ion-col>
+          <ion-col size="4">Usuário</ion-col>
+          <ion-col size="4">Email</ion-col>
+          <ion-col size="2">Cargo</ion-col>
           <ion-col size="2">Ações</ion-col>
         </ion-row>
         <ion-row *ngFor="let user of users" class="table-row">
-          <ion-col size="5">{{ user.name || user.user_id }}</ion-col>
-          <ion-col size="5">{{ user.email || '' }}</ion-col>
-          <ion-col size="2" *ngIf="user.user_id != userId ">
+          <ion-col size="4">{{ user.name || user.user_id }}</ion-col>
+          <ion-col size="4">{{ user.email || '' }}</ion-col>
+          <ion-col size="2">
+            <ion-select [(ngModel)]="user.role" (ionChange)="changeRole(user)" [disabled]="user.principal">
+              <ion-select-option value="admin">Admin</ion-select-option>
+              <ion-select-option value="member">Member</ion-select-option>
+            </ion-select>
+          </ion-col>
+          <ion-col size="2" *ngIf="user.user_id !== userId && !user.principal">
             <ion-button color="danger" size="small" (click)="remove(user.user_id)">
               <ion-icon slot="icon-only" name="trash"></ion-icon>
             </ion-button>

--- a/src/app/usuarios/usuarios.page.ts
+++ b/src/app/usuarios/usuarios.page.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { SeatsService } from '../services/seats.service';
 import { AuthService } from '../services/auth.service';
+import { UsuariosService, Usuario } from '../services/usuarios.service';
 
 @Component({
   selector: 'app-usuarios',
@@ -12,10 +13,11 @@ export class UsuariosPage {
   private seats = inject(SeatsService);
   private auth = inject(AuthService);
   private router = inject(Router);
+  private usuarios = inject(UsuariosService);
   public userId: any
 
   usage?: any;
-  users: any[] = [];
+  users: Usuario[] = [];
   newUserId = '';
 
   ionViewWillEnter(): void {
@@ -48,6 +50,22 @@ export class UsuariosPage {
     const tenantId = this.auth.getTenantId();
     if (tenantId && userId) {
       this.seats.remove(tenantId, userId).subscribe(() => this.load());
+    }
+  }
+
+  changeRole(user: Usuario): void {
+    if (user.principal) {
+      return;
+    }
+    const id = user.user_id ?? user.id;
+    const role = user.role;
+    if (!id) {
+      return;
+    }
+    if (confirm('Deseja alterar o cargo?')) {
+      this.usuarios.changeRole(id, role).subscribe(() => this.load());
+    } else {
+      this.load();
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow creating new users with name, email and password
- enable changing user roles when not marked as principal
- add `principal` optional flag to user profile types

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0615dc5848329a0a5d5bd9dfbcc21