### PR TITLE
feat: add client import job

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,8 @@ import { UsuariosNovoPage } from './usuarios-novo/usuarios-novo.page';
 import { PerfilPage } from './perfil/perfil.page';
 import { EmpresaPage } from './empresa/empresa.page';
 import { ConfiguracoesPage } from './configuracoes/configuracoes.page';
+
+import { ClientesImportarPage } from './clientes-importar/clientes-importar.page';
 import { FolderPage } from './folder/folder.page';
 import { SuportePage } from './suporte/suporte.page';
 
@@ -66,11 +68,12 @@ const routes: Routes = [
     canActivate: [AuthGuard],
     data: { title: 'Perfil' }
   },
+  
   {
-    path: 'empresa',
-    component: EmpresaPage,
+    path: 'clientes/importar',
+    component: ClientesImportarPage,
     canActivate: [AuthGuard],
-    data: { title: 'Empresa' }
+    data: { title: 'Importar Clientes' }
   },
   {
     path: 'configuracoes',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { UsuariosNovoPage } from './usuarios-novo/usuarios-novo.page';
 import { PerfilPage } from './perfil/perfil.page';
 import { EmpresaPage } from './empresa/empresa.page';
 import { ConfiguracoesPage } from './configuracoes/configuracoes.page';
+import { ClientesImportarPage } from './clientes-importar/clientes-importar.page';
 import { FolderPage } from './folder/folder.page';
 import { ListaClientesComponent } from './vendas-lista-clientes/lista-clientes/lista-clientes.component';
 import { ClienteModalComponent } from './vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component';
@@ -29,7 +30,7 @@ import { ClienteCardComponent } from './vendas-lista-clientes/lista-clientes/cli
 import { SuportePage } from './suporte/suporte.page';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage],
+  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage],
   imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule, FormsModule, ReactiveFormsModule, NgApexchartsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],

--- a/src/app/clientes-importar/clientes-importar.page.html
+++ b/src/app/clientes-importar/clientes-importar.page.html
@@ -1,0 +1,68 @@
+<ion-content class="ion-padding">
+  <ion-grid>
+    <ion-row>
+      <ion-col size="12" size-md="6">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Como importar</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <ion-list>
+              <ion-item lines="none">
+                <ion-icon slot="start" name="download-outline"></ion-icon>
+                <ion-label>Prepare um arquivo CSV com os dados dos clientes.</ion-label>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-icon slot="start" name="cloud-upload-outline"></ion-icon>
+                <ion-label>Arraste o arquivo para o campo ao lado ou clique para selecionar.</ion-label>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-icon slot="start" name="play-circle-outline"></ion-icon>
+                <ion-label>Após adicionar o arquivo, clique em "Importar".</ion-label>
+              </ion-item>
+            </ion-list>
+          </ion-card-content>
+        </ion-card>
+      </ion-col>
+      <ion-col size="12" size-md="6">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Importar Clientes</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <div class="dropzone" [class.dragover]="dragOver" (click)="openFileDialog(fileInput)" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
+              <ion-icon name="cloud-upload-outline" size="large"></ion-icon>
+              <p>Arraste e solte o arquivo CSV aqui ou clique para selecionar</p>
+              <input type="file" accept=".csv" (change)="onFileSelected($event)" #fileInput hidden />
+            </div>
+            <ion-list class="file-list" *ngIf="file">
+              <ion-item lines="none">
+                <ion-icon slot="start" name="document-text-outline"></ion-icon>
+                <ion-label>{{ file.name }}</ion-label>
+                <ion-button slot="end" fill="clear" color="danger" (click)="removeFile()">
+                  <ion-icon slot="icon-only" name="close-circle"></ion-icon>
+                </ion-button>
+              </ion-item>
+            </ion-list>
+            <ion-list class="csv-info">
+              <ion-item lines="none">
+                <ion-icon slot="start" name="list-outline"></ion-icon>
+                <ion-label>Separador: ponto e vírgula (;)</ion-label>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-icon slot="start" name="alert-circle-outline"></ion-icon>
+                <ion-label>Campos obrigatórios: nome, celular</ion-label>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-icon slot="start" name="information-circle-outline"></ion-icon>
+                <ion-label>Campos opcionais: status, cidade, id_usuario, indicacao, campanha, observacao</ion-label>
+              </ion-item>
+            </ion-list>
+            <ion-button expand="block" class="ion-margin-top" (click)="importar()" [disabled]="!file">Importar</ion-button>
+          </ion-card-content>
+        </ion-card>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</ion-content>
+

--- a/src/app/clientes-importar/clientes-importar.page.scss
+++ b/src/app/clientes-importar/clientes-importar.page.scss
@@ -1,0 +1,21 @@
+.dropzone {
+  border: 2px dashed var(--ion-color-medium);
+  padding: 2rem;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.dropzone.dragover {
+  border-color: var(--ion-color-primary);
+  background: rgba(var(--ion-color-primary-rgb), 0.05);
+}
+
+.file-list {
+  margin-top: 1rem;
+}
+
+.csv-info {
+  margin-top: 1rem;
+}
+

--- a/src/app/clientes-importar/clientes-importar.page.ts
+++ b/src/app/clientes-importar/clientes-importar.page.ts
@@ -1,0 +1,75 @@
+import { Component, inject } from '@angular/core';
+import { JobsService } from '../services/jobs.service';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-clientes-importar',
+  templateUrl: './clientes-importar.page.html',
+  styleUrls: ['./clientes-importar.page.scss'],
+  standalone: false,
+})
+export class ClientesImportarPage {
+  private jobs = inject(JobsService);
+  private alertController = inject(AlertController);
+
+  file: File | null = null;
+  dragOver = false;
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+    this.dragOver = true;
+  }
+
+  onDragLeave(event: DragEvent) {
+    event.preventDefault();
+    this.dragOver = false;
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    this.dragOver = false;
+    const droppedFile = event.dataTransfer?.files[0];
+    if (droppedFile) {
+      this.file = droppedFile;
+    }
+  }
+
+  onFileSelected(event: any) {
+    const selected = event.target.files[0];
+    this.file = selected ?? null;
+  }
+
+  removeFile() {
+    this.file = null;
+  }
+
+  openFileDialog(input: HTMLInputElement) {
+    input.click();
+  }
+
+  importar() {
+    if (!this.file) return;
+    this.jobs.postImportClients(this.file).subscribe({
+      next: () => {
+        this.alertController
+          .create({
+            header: 'Importação iniciada',
+            message: 'Job criado com sucesso.',
+            buttons: ['OK'],
+          })
+          .then((a) => a.present());
+        this.file = null;
+      },
+      error: () => {
+        this.alertController
+          .create({
+            header: 'Erro',
+            message: 'Não foi possível criar o job.',
+            buttons: ['OK'],
+          })
+          .then((a) => a.present());
+      },
+    });
+  }
+}
+

--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -44,6 +44,7 @@ export class NavMenuComponent {
         { icon: 'person-circle', title: 'Usuários', href: '/usuarios' },
         // { icon: 'business', title: 'Setores', href: '/setores' },
         { icon: 'business', title: 'Empresa', href: '/empresa' },
+        { icon: 'cloud-upload', title: 'Importar Clientes', href: '/clientes/importar' },
         { icon: 'person-add', title: 'Novo Usuário', href: '/usuarios/novo' },
       ],
     },

--- a/src/app/services/jobs.service.ts
+++ b/src/app/services/jobs.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class JobsService {
+  private http = inject(HttpClient);
+  private base = environment.apiUrl;
+  private jobsApi = `${this.base}/jobs`;
+  private adminApi = `${this.base}/admin/queues`;
+
+  postImportClients(file: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post(`${this.jobsApi}/import-clients`, formData);
+  }
+
+  postExportClients(payload: any = {}): Observable<any> {
+    return this.http.post(`${this.jobsApi}/export-clients`, payload);
+  }
+
+  getJob(queue: string, id: string): Observable<any> {
+    return this.http.get(`${this.jobsApi}/${queue}/${id}`);
+  }
+
+  cancelJob(queue: string, id: string): Observable<any> {
+    return this.http.delete(`${this.jobsApi}/${queue}/${id}`);
+  }
+
+  getQueues(): Observable<any> {
+    return this.http.get(this.adminApi);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add jobs service for importing, exporting and managing queues
- create Importar Clientes page with drag and drop CSV upload
- link Importar Clientes in admin menu and routing

## Testing
- `npm test` (fails: No binary for Chrome browser)
- `npm run lint` (fails: Prefer using the inject() function over constructor parameter injection)


------
https://chatgpt.com/codex/tasks/task_e_68b0d60a22d08329b444d2340389fa29