### PR TITLE
feat: add user jobs page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { ConfiguracoesPage } from './configuracoes/configuracoes.page';
 import { ClientesImportarPage } from './clientes-importar/clientes-importar.page';
 import { FolderPage } from './folder/folder.page';
 import { SuportePage } from './suporte/suporte.page';
+import { JobsPage } from './jobs/jobs.page';
 
 const routes: Routes = [
   {
@@ -25,6 +26,12 @@ const routes: Routes = [
   {
     path: 'login',
     loadChildren: () => import('./login/login.module').then( m => m.LoginPageModule)
+  },
+  {
+    path: 'jobs',
+    component: JobsPage,
+    canActivate: [AuthGuard],
+    data: { title: 'Meus Trabalhos' }
   },
   {
     path: 'vendas/dashboard',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,9 +28,10 @@ import { ListaClientesComponent } from './vendas-lista-clientes/lista-clientes/l
 import { ClienteModalComponent } from './vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component';
 import { ClienteCardComponent } from './vendas-lista-clientes/lista-clientes/cliente-card/cliente-card.component';
 import { SuportePage } from './suporte/suporte.page';
+import { JobsPage } from './jobs/jobs.page';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage],
+  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage, JobsPage],
   imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule, FormsModule, ReactiveFormsModule, NgApexchartsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],

--- a/src/app/jobs/jobs.page.html
+++ b/src/app/jobs/jobs.page.html
@@ -1,0 +1,33 @@
+<ion-content class="ion-padding">
+  <ion-card class="ion-margin-bottom">
+    <ion-card-header>
+      <ion-card-title>Meus Trabalhos</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p>
+        Aqui ficam os trabalhos do sistema como importação e exportação de
+        clientes.
+      </p>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Trabalhos</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-grid class="jobs-grid">
+        <ion-row class="header">
+          <ion-col>Fila</ion-col>
+          <ion-col>ID</ion-col>
+          <ion-col>Estado</ion-col>
+        </ion-row>
+        <ion-row *ngFor="let job of jobs">
+          <ion-col>{{ job.queue || job.queueName }}</ion-col>
+          <ion-col>{{ job.id }}</ion-col>
+          <ion-col>{{ job.state }}</ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/src/app/jobs/jobs.page.scss
+++ b/src/app/jobs/jobs.page.scss
@@ -1,0 +1,10 @@
+.jobs-grid {
+  .header {
+    font-weight: bold;
+    border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  }
+  ion-row {
+    align-items: center;
+    padding: 8px 0;
+  }
+}

--- a/src/app/jobs/jobs.page.ts
+++ b/src/app/jobs/jobs.page.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { JobsService } from '../services/jobs.service';
+
+@Component({
+  selector: 'app-jobs',
+  templateUrl: './jobs.page.html',
+  styleUrls: ['./jobs.page.scss'],
+  standalone: false,
+})
+export class JobsPage implements OnInit {
+  private jobsService = inject(JobsService);
+  jobs: any[] = [];
+
+  ngOnInit(): void {
+    this.jobsService.listUserJobs().subscribe({
+      next: (res) => {
+        this.jobs = (res as any)?.data ?? res ?? [];
+      },
+      error: () => {
+        this.jobs = [];
+      },
+    });
+  }
+}

--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -31,6 +31,12 @@ export class NavMenuComponent {
   @HostBinding('class.collapsed') collapsed = false;
   public menuSections: MenuSection[] = [
     {
+      title: 'Geral',
+      items: [
+        { icon: 'briefcase', title: 'Meus Trabalhos', href: '/jobs' },
+      ],
+    },
+    {
       title: 'Vendas',
       items: [
         { icon: 'stats-chart', title: 'Relatório de Vendas', href: '/vendas/dashboard' },

--- a/src/app/services/jobs.service.ts
+++ b/src/app/services/jobs.service.ts
@@ -10,6 +10,15 @@ export class JobsService {
   private jobsApi = `${this.base}/jobs`;
   private adminApi = `${this.base}/admin/queues`;
 
+  listUserJobs(
+    states: string = 'waiting,active,completed,failed',
+    limit: number = 50
+  ): Observable<any> {
+    return this.http.get(`${this.jobsApi}/user`, {
+      params: { states, limit },
+    });
+  }
+
   postImportClients(file: File): Observable<any> {
     const formData = new FormData();
     formData.append('file', file);


### PR DESCRIPTION
## Summary
- add method to fetch user jobs
- add Meus Trabalhos page and routing
- expose jobs page in navigation menu

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: 6 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b1febbf5f48329a8d4a0f09ba988aa