### PR TITLE
feat: improve jobs loading and clients pagination

### DIFF
--- a/src/app/jobs/jobs.page.html
+++ b/src/app/jobs/jobs.page.html
@@ -16,7 +16,10 @@
       <ion-card-title>Trabalhos</ion-card-title>
     </ion-card-header>
     <ion-card-content>
-      <ion-grid class="jobs-grid">
+      <div class="ion-text-center" *ngIf="loading">
+        <ion-spinner name="crescent"></ion-spinner>
+      </div>
+      <ion-grid class="jobs-grid" *ngIf="!loading">
         <ion-row class="header">
           <ion-col>Fila</ion-col>
           <ion-col>ID</ion-col>

--- a/src/app/jobs/jobs.page.ts
+++ b/src/app/jobs/jobs.page.ts
@@ -10,6 +10,7 @@ import { JobsService } from '../services/jobs.service';
 export class JobsPage implements OnInit {
   private jobsService = inject(JobsService);
   jobs: any[] = [];
+  loading = false;
 
   ngOnInit(): void {
     this.loadJobs();
@@ -20,13 +21,16 @@ export class JobsPage implements OnInit {
   }
 
   private loadJobs(): void {
+    this.loading = true;
     this.jobsService.listUserJobs().subscribe({
       next: (res) => {
         const data = (res as any)?.data ?? res;
         this.jobs = data?.jobs ?? data ?? [];
+        this.loading = false;
       },
       error: () => {
         this.jobs = [];
+        this.loading = false;
       },
     });
   }

--- a/src/app/services/clientes.service.ts
+++ b/src/app/services/clientes.service.ts
@@ -21,7 +21,7 @@ export interface Cliente {
 
 export interface ClientesResponse {
   data: Cliente[];
-  meta: { total: number; totalPages: number };
+  meta: { total: number; page: number; perPage: number; totalPages: number };
 }
 
 export interface ClienteEvento {
@@ -49,8 +49,8 @@ export class ClientesService {
     return this.http.get<{ cidades: string[]; status: string[] }>(`${this.api}/filtros`);
   }
 
-  getClientes(params: any): Observable<Cliente[]> {
-    return this.http.get<Cliente[]>(this.api, { params });
+  getClientes(params: any): Observable<ClientesResponse> {
+    return this.http.get<ClientesResponse>(this.api, { params });
   }
 
   getEventosDoCliente(idCliente: number, params: any = {}): Observable<ClienteEvento[]> {

--- a/src/app/usuarios/usuarios.page.html
+++ b/src/app/usuarios/usuarios.page.html
@@ -24,14 +24,30 @@
     <ion-card-content>
       <ion-grid class="table-view">
         <ion-row class="table-header">
-          <ion-col size="4">Usuário</ion-col>
-          <ion-col size="4">Email</ion-col>
+          <ion-col size="3">Usuário</ion-col>
+          <ion-col size="3">Email</ion-col>
+          <ion-col size="2">ID</ion-col>
           <ion-col size="2">Cargo</ion-col>
           <ion-col size="2">Ações</ion-col>
         </ion-row>
-        <ion-row *ngFor="let user of users" class="table-row">
-          <ion-col size="4">{{ user.name || user.user_id }}</ion-col>
-          <ion-col size="4">{{ user.email || '' }}</ion-col>
+        <ion-row *ngFor="let user of users; let i = index" class="table-row">
+          <ion-col size="3">{{ user.name || user.user_id }}</ion-col>
+          <ion-col size="3">{{ user.email || '' }}</ion-col>
+          <ion-col size="2">
+            <div style="display: flex; align-items: center; gap: 4px;">
+              <span id="user-id-{{ i }}" style="cursor: pointer;">
+                {{ truncateId(user.user_id || user.id) }}
+              </span>
+              <ion-button fill="clear" size="small" (click)="copyId(user.user_id || user.id)">
+                <ion-icon slot="icon-only" name="copy-outline"></ion-icon>
+              </ion-button>
+            </div>
+            <ion-popover trigger="user-id-{{ i }}" triggerAction="click">
+              <ng-template>
+                <ion-content class="ion-padding">{{ user.user_id || user.id }}</ion-content>
+              </ng-template>
+            </ion-popover>
+          </ion-col>
           <ion-col size="2">
             <ion-select [(ngModel)]="user.role" (ionChange)="changeRole(user)" [disabled]="user.principal ?? false">
               <ion-select-option value="admin">Admin</ion-select-option>

--- a/src/app/usuarios/usuarios.page.ts
+++ b/src/app/usuarios/usuarios.page.ts
@@ -68,5 +68,18 @@ export class UsuariosPage {
       this.load();
     }
   }
+
+  truncateId(id: string): string {
+    if (!id) {
+      return '';
+    }
+    return id.length > 10 ? `${id.slice(0, 10)}...` : id;
+  }
+
+  copyId(id: string): void {
+    if (id) {
+      navigator.clipboard.writeText(id);
+    }
+  }
 }
 

--- a/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.html
+++ b/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.html
@@ -76,7 +76,7 @@
           </ion-col>
 
           <ion-col size="12" class="ion-text-right">
-            <ion-button color="primary" (click)="pesquisaAvancada()" [disabled]="carregandoBusca">
+            <ion-button color="primary" (click)="pesquisaAvancada(true)" [disabled]="carregandoBusca">
               <ion-spinner slot="start" *ngIf="carregandoBusca" name="crescent"></ion-spinner>
               Buscar na base
             </ion-button>

--- a/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/lista-clientes.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { ClientesService, Cliente } from '../../services/clientes.service';
+import { ClientesService, Cliente, ClientesResponse } from '../../services/clientes.service';
 import { AuthService } from '../../services/auth.service';
 import { ViewPreferenceService } from '../../services/view-preference.service';
 
@@ -49,7 +49,7 @@ export class ListaClientesComponent implements OnInit {
   private buildParams(extra: any = {}) {
     const base: any = {
       page: this.page,
-      pageSize: this.pageSize,
+      perPage: this.pageSize,
       sortBy: this.sortBy,
     };
 
@@ -76,25 +76,30 @@ export class ListaClientesComponent implements OnInit {
   fetch(): void {
     this.carregandoBusca = true;
     this.clientesService.getClientes(this.buildParams()).subscribe({
-      next: (resp: Cliente[]) => {
-        console.log(resp)
-        this.clientes = resp;
-        this.total = resp.length;
-        this.totalPages = 1;
+      next: (resp: ClientesResponse) => {
+        this.clientes = resp.data;
+        this.total = resp.meta.total;
+        this.totalPages = resp.meta.totalPages;
+        this.page = resp.meta.page;
+        this.pageSize = resp.meta.perPage;
         this.carregandoBusca = false;
       },
       error: () => (this.carregandoBusca = false),
     });
   }
 
-  pesquisaAvancada(): void {
-    this.page = 1;
+  pesquisaAvancada(resetPage = false): void {
+    if (resetPage) {
+      this.page = 1;
+    }
     this.carregandoBusca = true;
     this.clientesService.getClientes(this.buildParams({ fromSearch: true })).subscribe({
-      next: (resp: Cliente[]) => {
-        this.clientes = resp;
-        this.total = resp.length;
-        this.totalPages = 1;
+      next: (resp: ClientesResponse) => {
+        this.clientes = resp.data;
+        this.total = resp.meta.total;
+        this.totalPages = resp.meta.totalPages;
+        this.page = resp.meta.page;
+        this.pageSize = resp.meta.perPage;
         this.carregandoBusca = false;
       },
       error: () => (this.carregandoBusca = false),


### PR DESCRIPTION
## Summary
- add loading spinner to jobs page
- show truncated user ID with tooltip and copy button
- fix clients pagination using new API metadata

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b20a9c75d88329835f30a273c29dcc