### PR TITLE
feat: show job metadata

### DIFF
--- a/src/app/jobs/jobs.page.html
+++ b/src/app/jobs/jobs.page.html
@@ -24,6 +24,7 @@
           <ion-col>Fila</ion-col>
           <ion-col>ID</ion-col>
           <ion-col>Estado</ion-col>
+          <ion-col>Ações</ion-col>
         </ion-row>
         <ion-row *ngFor="let job of jobs">
           <ion-col>{{ translateQueue(job.queue || job.queueName) }}</ion-col>
@@ -33,8 +34,45 @@
               {{ translateState(job) }}
             </ion-badge>
           </ion-col>
+          <ion-col>
+            <ion-button size="small" (click)="viewData(job)" [disabled]="job.state !== 'completed'">
+              Ver Dados
+            </ion-button>
+          </ion-col>
         </ion-row>
       </ion-grid>
     </ion-card-content>
   </ion-card>
+  <ion-modal [isOpen]="metadataOpen" (didDismiss)="closeMetadata()">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar color="primary">
+          <ion-title>Dados do Trabalho</ion-title>
+          <ion-buttons slot="end">
+            <ion-button (click)="closeMetadata()">
+              <ion-icon slot="icon-only" name="close"></ion-icon>
+            </ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <div class="ion-text-center" *ngIf="metadataLoading">
+          <ion-spinner name="crescent"></ion-spinner>
+        </div>
+        <ion-grid class="metadata-grid" *ngIf="!metadataLoading && metadata.length > 0">
+          <ion-row class="header">
+            <ion-col>Nome</ion-col>
+            <ion-col>Valor</ion-col>
+          </ion-row>
+          <ion-row *ngFor="let item of metadata">
+            <ion-col>{{ item.label }}</ion-col>
+            <ion-col>{{ item.value }}</ion-col>
+          </ion-row>
+        </ion-grid>
+        <ion-text color="medium" *ngIf="!metadataLoading && metadata.length === 0">
+          Nenhum dado disponível.
+        </ion-text>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
 </ion-content>

--- a/src/app/jobs/jobs.page.scss
+++ b/src/app/jobs/jobs.page.scss
@@ -11,3 +11,14 @@
     text-transform: none;
   }
 }
+
+.metadata-grid {
+  .header {
+    font-weight: bold;
+    border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  }
+  ion-row {
+    align-items: center;
+    padding: 8px 0;
+  }
+}

--- a/src/app/jobs/jobs.page.ts
+++ b/src/app/jobs/jobs.page.ts
@@ -11,6 +11,9 @@ export class JobsPage implements OnInit {
   private jobsService = inject(JobsService);
   jobs: any[] = [];
   loading = false;
+  metadataOpen = false;
+  metadataLoading = false;
+  metadata: { label: string; value: any }[] = [];
 
   ngOnInit(): void {
     this.loadJobs();
@@ -33,6 +36,27 @@ export class JobsPage implements OnInit {
         this.loading = false;
       },
     });
+  }
+
+  viewData(job: any): void {
+    const queue = job.queue || job.queueName;
+    this.metadataOpen = true;
+    this.metadataLoading = true;
+    this.metadata = [];
+    this.jobsService.getJob(queue, job.id).subscribe({
+      next: (res) => {
+        this.metadata = res?.result?.metadata ?? [];
+        this.metadataLoading = false;
+      },
+      error: () => {
+        this.metadata = [];
+        this.metadataLoading = false;
+      },
+    });
+  }
+
+  closeMetadata(): void {
+    this.metadataOpen = false;
   }
 
   translateQueue(queue: string): string {


### PR DESCRIPTION
## Summary
- exibe botão **Ver Dados** na lista de trabalhos
- adiciona modal para visualizar metadados do job
- inclui estilos para tabela de metadados

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_e_68b227f2ff7083299524032edb9dd894