### PR TITLE
feat(nav-menu): persist collapse state

### DIFF
--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, inject } from '@angular/core';
+import { AfterViewInit, Component, HostBinding, OnInit, inject } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 
 interface MenuItem {
@@ -26,7 +26,7 @@ interface SubItem {
   styleUrls: ['./nav-menu.component.scss'],
   standalone: false,
 })
-export class NavMenuComponent {
+export class NavMenuComponent implements OnInit, AfterViewInit {
   private auth = inject(AuthService);
   @HostBinding('class.collapsed') collapsed = false;
   public menuSections: MenuSection[] = [
@@ -78,14 +78,8 @@ export class NavMenuComponent {
 
   toggleCollapse(): void {
     this.collapsed = !this.collapsed;
-    const menu = document.querySelector('ion-menu.menu-desktop');
-    if (menu) {
-      if (this.collapsed) {
-        menu.classList.add('collapsed');
-      } else {
-        menu.classList.remove('collapsed');
-      }
-    }
+    localStorage.setItem('navMenuCollapsed', this.collapsed.toString());
+    this.applyCollapsedClass();
   }
 
   isAdmin(): boolean {
@@ -95,6 +89,22 @@ export class NavMenuComponent {
   isAdminSection(section: MenuSection): boolean {
     const title = (section?.title || '').toString();
     return title.startsWith('Administra');
+  }
+
+  ngOnInit(): void {
+    const stored = localStorage.getItem('navMenuCollapsed');
+    this.collapsed = stored === 'true';
+  }
+
+  ngAfterViewInit(): void {
+    this.applyCollapsedClass();
+  }
+
+  private applyCollapsedClass(): void {
+    const menu = document.querySelector('ion-menu.menu-desktop');
+    if (menu) {
+      menu.classList.toggle('collapsed', this.collapsed);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- persist nav menu collapsed state across reloads using localStorage

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_e_68b22df7d5cc8329855e9beeba23aba8