### PR TITLE
feat: add mensagens padrao page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { ClientesImportarPage } from './clientes-importar/clientes-importar.page
 import { FolderPage } from './folder/folder.page';
 import { SuportePage } from './suporte/suporte.page';
 import { JobsPage } from './jobs/jobs.page';
+import { MensagensPadraoPage } from './mensagens-padrao/mensagens-padrao.page';
 
 const routes: Routes = [
   {
@@ -56,6 +57,12 @@ const routes: Routes = [
     component: VendasListaClientesPage,
     canActivate: [AuthGuard],
     data: { title: 'Lista de Clientes' }
+  },
+  {
+    path: 'vendas/mensagens-padrao',
+    component: MensagensPadraoPage,
+    canActivate: [AuthGuard],
+    data: { title: 'Mensagens Padrão' }
   },
   {
     path: 'usuarios',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,9 +29,10 @@ import { ClienteModalComponent } from './vendas-lista-clientes/lista-clientes/cl
 import { ClienteCardComponent } from './vendas-lista-clientes/lista-clientes/cliente-card/cliente-card.component';
 import { SuportePage } from './suporte/suporte.page';
 import { JobsPage } from './jobs/jobs.page';
+import { MensagensPadraoPage } from './mensagens-padrao/mensagens-padrao.page';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage, JobsPage],
+  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, EmpresaPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage, JobsPage, MensagensPadraoPage],
   imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule, FormsModule, ReactiveFormsModule, NgApexchartsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],

--- a/src/app/mensagens-padrao/mensagens-padrao.page.html
+++ b/src/app/mensagens-padrao/mensagens-padrao.page.html
@@ -1,0 +1,48 @@
+<ion-content class="ion-padding">
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>{{ editando ? 'Editar Mensagem' : 'Nova Mensagem Padrão' }}</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <form [formGroup]="form" (ngSubmit)="salvar()">
+        <ion-item>
+          <ion-label position="stacked">Nome</ion-label>
+          <ion-input formControlName="nome"></ion-input>
+        </ion-item>
+        <ion-item lines="none">
+          <ion-label position="stacked">Mensagem</ion-label>
+          <textarea formControlName="mensagem" class="whatsapp-field"></textarea>
+        </ion-item>
+        <ion-button expand="block" type="submit" [disabled]="form.invalid">
+          {{ editando ? 'Atualizar' : 'Cadastrar' }}
+        </ion-button>
+        <ion-button *ngIf="editando" expand="block" fill="clear" color="medium" (click)="cancelar()">
+          Cancelar
+        </ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Mensagens Salvas</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list>
+        <ion-item *ngFor="let msg of mensagens">
+          <ion-label>
+            <h2>{{ msg.nome }}</h2>
+            <p class="whatsapp-field">{{ msg.mensagem }}</p>
+          </ion-label>
+          <ion-button fill="clear" color="medium" (click)="editar(msg)">
+            <ion-icon slot="icon-only" name="create"></ion-icon>
+          </ion-button>
+          <ion-button fill="clear" color="danger" (click)="remover(msg)">
+            <ion-icon slot="icon-only" name="trash"></ion-icon>
+          </ion-button>
+        </ion-item>
+      </ion-list>
+    </ion-card-content>
+  </ion-card>
+</ion-content>
+

--- a/src/app/mensagens-padrao/mensagens-padrao.page.scss
+++ b/src/app/mensagens-padrao/mensagens-padrao.page.scss
@@ -1,0 +1,15 @@
+.whatsapp-field {
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 16px;
+  line-height: 1.4;
+  background: #fff;
+  white-space: pre-wrap;
+}
+
+ion-item .whatsapp-field {
+  margin-top: 8px;
+  min-height: 80px;
+}

--- a/src/app/mensagens-padrao/mensagens-padrao.page.ts
+++ b/src/app/mensagens-padrao/mensagens-padrao.page.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MensagensPadraoService, MensagemPadrao } from '../services/mensagens-padrao.service';
+
+@Component({
+  selector: 'app-mensagens-padrao',
+  templateUrl: './mensagens-padrao.page.html',
+  styleUrls: ['./mensagens-padrao.page.scss'],
+})
+export class MensagensPadraoPage implements OnInit {
+  form: FormGroup;
+  mensagens: MensagemPadrao[] = [];
+  editando: MensagemPadrao | null = null;
+
+  constructor(private fb: FormBuilder, private service: MensagensPadraoService) {
+    this.form = this.fb.group({
+      nome: ['', Validators.required],
+      mensagem: ['', Validators.required],
+    });
+  }
+
+  ngOnInit() {
+    this.carregar();
+  }
+
+  carregar() {
+    this.service.listar().subscribe(res => {
+      this.mensagens = res.dados || [];
+    });
+  }
+
+  salvar() {
+    if (this.form.invalid) return;
+    const valor = this.form.value;
+    if (this.editando) {
+      this.service.atualizar(this.editando.idMensagem!, valor).subscribe(() => {
+        this.cancelar();
+        this.carregar();
+      });
+    } else {
+      this.service.criar(valor).subscribe(() => {
+        this.form.reset();
+        this.carregar();
+      });
+    }
+  }
+
+  editar(msg: MensagemPadrao) {
+    this.editando = msg;
+    this.form.patchValue({ nome: msg.nome, mensagem: msg.mensagem });
+  }
+
+  remover(msg: MensagemPadrao) {
+    if (confirm('Remover mensagem?')) {
+      this.service.remover(msg.idMensagem!).subscribe(() => this.carregar());
+    }
+  }
+
+  cancelar() {
+    this.editando = null;
+    this.form.reset();
+  }
+}
+

--- a/src/app/nav-menu/nav-menu.component.ts
+++ b/src/app/nav-menu/nav-menu.component.ts
@@ -42,6 +42,7 @@ export class NavMenuComponent implements OnInit, AfterViewInit {
         { icon: 'stats-chart', title: 'Relatório de Vendas', href: '/vendas/dashboard' },
         { icon: 'person-add-outline', title: 'Cadastrar Clientes', href: '/vendas/leads' },
         { icon: 'people', title: 'Lista de Clientes', href: '/vendas/lista/clientes' },
+        { icon: 'chatbubbles', title: 'Mensagens Padrão', href: '/vendas/mensagens-padrao' },
       ],
     },
     {

--- a/src/app/services/mensagens-padrao.service.ts
+++ b/src/app/services/mensagens-padrao.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface MensagemPadrao {
+  idMensagem?: number;
+  nome: string;
+  mensagem: string;
+}
+
+export interface ListaMensagensResponse {
+  sucesso: boolean;
+  total: number;
+  pagina: number;
+  limite: number;
+  dados: MensagemPadrao[];
+}
+
+export interface MensagemResponse {
+  sucesso: boolean;
+  mensagem: string;
+  dado: MensagemPadrao;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MensagensPadraoService {
+  private http = inject(HttpClient);
+  private api = `${environment.apiUrl}/apo/mensagens-padrao`;
+
+  listar(q = '', page = 1, limit = 50): Observable<ListaMensagensResponse> {
+    return this.http.get<ListaMensagensResponse>(this.api, {
+      params: { q, page, limit }
+    });
+  }
+
+  criar(payload: { nome: string; mensagem: string }): Observable<MensagemResponse> {
+    return this.http.post<MensagemResponse>(this.api, payload);
+  }
+
+  atualizar(id: number, payload: Partial<MensagemPadrao>): Observable<MensagemResponse> {
+    return this.http.put<MensagemResponse>(`${this.api}/${id}`, payload);
+  }
+
+  remover(id: number): Observable<{ sucesso: boolean; mensagem: string }> {
+    return this.http.delete<{ sucesso: boolean; mensagem: string }>(`${this.api}/${id}`);
+  }
+}
+

--- a/temp_nav.ts
+++ b/temp_nav.ts
@@ -36,6 +36,7 @@ export class NavMenuComponent {
         { icon: 'stats-chart', title: 'RelatÃ³rio de Vendas', href: '/vendas/dashboard' },
         { icon: 'person-add-outline', title: 'Cadastrar Clientes', href: '/vendas/leads' },
         { icon: 'people', title: 'Lista de Clientes', href: '/vendas/lista/clientes' },
+        { icon: 'chatbubbles', title: 'Mensagens PadrÃ£o', href: '/vendas/mensagens-padrao' },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- add messages padrao service and page
- wire up route and navigation entry
- style message fields similar to WhatsApp

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a2adb5988329aa21b96d93561cab