### PR TITLE
feat: add newsletter modal for onboarding

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,4 +22,5 @@
 
     </ion-split-pane>
   </ng-template>
+  <app-newsletter></app-newsletter>
 </ion-app>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,9 +29,11 @@ import { ClienteCardComponent } from './vendas-lista-clientes/lista-clientes/cli
 import { SuportePage } from './suporte/suporte.page';
 import { JobsPage } from './jobs/jobs.page';
 import { MensagensPadraoPage } from './mensagens-padrao/mensagens-padrao.page';
+import { NewsletterComponent } from './newsletter/newsletter.component';
+import { WelcomeComponent } from './newsletter/news/welcome/welcome.component';
 
 @NgModule({
-  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage, JobsPage, MensagensPadraoPage],
+  declarations: [AppComponent, NavMenuComponent, VendasDashboardPage, VendasLeadsPage, VendasListaClientesPage, UsuariosPage, SetoresPage, UsuariosNovoPage, PerfilPage, ConfiguracoesPage, ClientesImportarPage, FolderPage, ListaClientesComponent,ClienteModalComponent, ClienteCardComponent, SuportePage, JobsPage, MensagensPadraoPage, NewsletterComponent, WelcomeComponent],
   imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule, HttpClientModule, ComponentsModule, FormsModule, ReactiveFormsModule, NgApexchartsModule,
     LucideAngularModule.pick({ UserPlus, Phone, Users, Calendar, Receipt })
    ],

--- a/src/app/newsletter/news/welcome/welcome.component.html
+++ b/src/app/newsletter/news/welcome/welcome.component.html
@@ -1,0 +1,4 @@
+<div class="welcome">
+  <h2>Bem-vindo!</h2>
+  <p>Estamos felizes em tê-lo conosco.</p>
+</div>

--- a/src/app/newsletter/news/welcome/welcome.component.scss
+++ b/src/app/newsletter/news/welcome/welcome.component.scss
@@ -1,0 +1,3 @@
+.welcome {
+  text-align: center;
+}

--- a/src/app/newsletter/news/welcome/welcome.component.ts
+++ b/src/app/newsletter/news/welcome/welcome.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-news-welcome',
+  templateUrl: './welcome.component.html',
+  styleUrls: ['./welcome.component.scss'],
+})
+export class WelcomeComponent {}

--- a/src/app/newsletter/newsletter.component.html
+++ b/src/app/newsletter/newsletter.component.html
@@ -1,0 +1,19 @@
+<ion-modal [isOpen]="isOpen" [backdropDismiss]="false">
+  <ng-container *ngIf="current">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>{{ current.title }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding">
+      <ng-container *ngComponentOutlet="current.component"></ng-container>
+    </ion-content>
+
+    <ion-footer>
+      <ion-toolbar>
+        <ion-button expand="block" (click)="continue()">Continuar</ion-button>
+      </ion-toolbar>
+    </ion-footer>
+  </ng-container>
+</ion-modal>

--- a/src/app/newsletter/newsletter.component.scss
+++ b/src/app/newsletter/newsletter.component.scss
@@ -1,0 +1,4 @@
+ion-modal {
+  --width: 90%;
+  --max-width: 500px;
+}

--- a/src/app/newsletter/newsletter.component.ts
+++ b/src/app/newsletter/newsletter.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { WelcomeComponent } from './news/welcome/welcome.component';
+
+interface NewsItem {
+  name: string;
+  title: string;
+  component: any;
+}
+
+@Component({
+  selector: 'app-newsletter',
+  templateUrl: './newsletter.component.html',
+  styleUrls: ['./newsletter.component.scss'],
+})
+export class NewsletterComponent implements OnInit {
+  queue: NewsItem[] = [
+    { name: 'welcome', title: 'Bem-vindo', component: WelcomeComponent },
+  ];
+
+  current?: NewsItem;
+  isOpen = false;
+
+  ngOnInit(): void {
+    this.next();
+  }
+
+  continue(): void {
+    if (this.current) {
+      localStorage.setItem(`newsletter_${this.current.name}`, '1');
+    }
+    this.next();
+  }
+
+  private next(): void {
+    this.current = undefined;
+    for (const item of this.queue) {
+      if (!localStorage.getItem(`newsletter_${item.name}`)) {
+        this.current = item;
+        break;
+      }
+    }
+    this.isOpen = !!this.current;
+  }
+}


### PR DESCRIPTION
## Summary
- add newsletter modal that queues onboarding components
- show welcome news and store completion state

## Testing
- `npm run lint` (fails: Prefer using the inject() function over constructor parameter injection)
- `npm test` (fails: No binary for Chrome browser on your platform)

------
https://chatgpt.com/codex/tasks/task_e_68b4b88b1fe88329bc8607812c4255ea