### PR TITLE
feat(client-modal): add optional time picker

### DIFF
--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.html
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.html
@@ -96,8 +96,25 @@
             <ion-input placeholder="Título do evento" [(ngModel)]="evTitulo"></ion-input>
           </ion-item>
           <ion-item>
-            <ion-datetime presentation="date-time" [(ngModel)]="evData"></ion-datetime>
+            <ion-label position="stacked">Data</ion-label>
+            <ion-datetime
+              presentation="date"
+              [preferWheel]="true"
+              [(ngModel)]="evDate"
+            ></ion-datetime>
           </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Hora (opcional)</ion-label>
+            <ion-datetime
+              presentation="time"
+              [preferWheel]="true"
+              [(ngModel)]="evTime"
+            ></ion-datetime>
+          </ion-item>
+          <ion-text color="medium" class="event-hint">
+            * Se não informar hora, será considerado 00:00 no seu fuso
+            (America/Fortaleza).
+          </ion-text>
           <ion-button expand="block" (click)="marcarEvento()" [disabled]="isSavingEvento">
             <ion-icon slot="start" name="calendar-outline"></ion-icon>
             Marcar

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.scss
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.scss
@@ -13,3 +13,16 @@
   align-items: center;
   justify-content: space-between;
 }
+
+.event-hint {
+  display: block;
+  font-size: 0.8rem;
+  margin: 4px 16px;
+}
+
+@media (max-width: 600px) {
+  .cliente-modal {
+    --width: 95%;
+    --height: 90%;
+  }
+}

--- a/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.ts
+++ b/src/app/vendas-lista-clientes/lista-clientes/cliente-modal/cliente-modal.component.ts
@@ -25,7 +25,8 @@ export class ClienteModalComponent implements OnChanges {
   // eventos
   eventos: ClienteEvento[] = [];
   evTitulo = '';
-  evData = '';
+  evDate = '';
+  evTime: string | null = null;
   isSavingEvento = false;
   isLoadingEventos = false;
   tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Maceio';
@@ -135,21 +136,23 @@ export class ClienteModalComponent implements OnChanges {
   }
 
   marcarEvento() {
-    if (!this.evData) {
+    if (!this.evDate) {
       return;
     }
+    const data = `${this.evDate}T${this.evTime || '00:00'}`;
     this.isSavingEvento = true;
     this.clientesService.criarEvento({
       id_usuario: this.idUsuario,
       id_cliente: this.formData.id_cliente,
-      data: this.evData,
+      data,
       evento: this.evTitulo || null,
       tz: this.tz
     }).subscribe({
       next: novo => {
         this.eventos.unshift(novo);
         this.evTitulo = '';
-        this.evData = '';
+        this.evDate = '';
+        this.evTime = null;
         this.isSavingEvento = false;
       },
       error: () => {


### PR DESCRIPTION
## Summary
- add date and optional time pickers for client events with mobile-friendly wheel selectors
- note about defaulting to midnight when time omitted and improve modal mobile layout

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c1681294832999ca4a8c24a003c0